### PR TITLE
Fixed including json and charconv

### DIFF
--- a/src/app/app.hpp
+++ b/src/app/app.hpp
@@ -8,6 +8,7 @@
 #include <fstream>
 #include <iostream>
 #include <filesystem>
+#include <charconv>
 #include "../../vendor/code/tinyfiledialogs.h"
 #include "../../vendor/log/clue.hpp"
 #include <tsl/ordered_map.h>
@@ -26,7 +27,7 @@
 #include "../../vendor/hex/hex.h"
 #include "integration/interpreter/interpreter.hpp"
 #include "windows/windows.hpp"
-#include "nlohmann/json.hpp"
+#include "../../vendor/json/json.hpp"
 #include <capstone/capstone.h>
 #include "actions/actions.hpp"
 using json = nlohmann::json;


### PR DESCRIPTION
- Fixed json include 
- Added `#include <charconv>` regarding the issue: https://github.com/ZathuraDbg/ZathuraDbg/issues/91
- Tested on Ubuntu