### PR TITLE
Fix debugger stability and add ELF loader tests

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -103,6 +103,7 @@ set(SRC_INTEGRATION
     ${APP_DIR}/integration/interpreter/execution.cpp
     ${APP_DIR}/integration/interpreter/breakpoints.cpp
     ${APP_DIR}/integration/gdb/gdbRemote.cpp
+    ${APP_DIR}/integration/gdb/gdbPacket.cpp
     ${APP_DIR}/integration/gdb/elfSymbols.cpp
     ${APP_DIR}/integration/keystone/assembler.cpp
 )

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
 project(Zathura)
+enable_testing()
 
 set(CMAKE_CXX_STANDARD 23)
 set(OPTIMIZATION_LEVEL "O0" CACHE STRING "Optimization level (O0, Og, O1, O2, O3)")
@@ -186,6 +187,15 @@ set_source_files_properties(${SRC_VENDOR_C} PROPERTIES SKIP_PRECOMPILE_HEADERS O
 
 # Debug info comes from CMAKE_*_FLAGS_DEBUG; avoid passing -g twice.
 target_compile_options(${PROJECT_NAME} PRIVATE -Wformat -pipe)
+
+if (NOT WIN32)
+    add_executable(zathura_elf_symbols_test
+            ${APP_DIR}/integration/gdb/elfSymbols.cpp
+            ${PROJECT_ROOT}/tests/elfSymbolsTest.cpp
+    )
+    target_include_directories(zathura_elf_symbols_test PRIVATE ${APP_DIR})
+    add_test(NAME zathura_elf_symbols_test COMMAND zathura_elf_symbols_test)
+endif()
 
 # Platform-specific target settings
 if (UNIX AND NOT APPLE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -193,6 +193,7 @@ if (NOT WIN32)
             ${APP_DIR}/integration/gdb/elfSymbols.cpp
             ${PROJECT_ROOT}/tests/elfSymbolsTest.cpp
     )
+    set_target_properties(zathura_elf_symbols_test PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
     target_include_directories(zathura_elf_symbols_test PRIVATE ${APP_DIR})
     add_test(NAME zathura_elf_symbols_test COMMAND zathura_elf_symbols_test)
 endif()

--- a/src/app/actions/actions.cpp
+++ b/src/app/actions/actions.cpp
@@ -151,14 +151,13 @@ void stepBack()
 
     safeHighlightLine(addressLineNoMap[icicle_get_pc(icicle)] - 1);
     updateRegs(false);
-    icicle_vm_snapshot_free(stateToRestore);
 
-    if (snapshot) {
+    if (snapshot && snapshot != stateToRestore) {
         icicle_vm_snapshot_free(snapshot);
-        snapshot = nullptr;
     }
 
     snapshot = icicle_vm_snapshot(icicle);
+    icicle_vm_snapshot_free(stateToRestore);
     LOG_DEBUG("Stepped back successfully. Snapshots remaining: " << vmSnapshots.size());
 }
 

--- a/src/app/app.cpp
+++ b/src/app/app.cpp
@@ -195,7 +195,10 @@ void mainWindow() {
     ImGui::Begin("Register Values", &keepWindow, ImGuiWindowFlags_NoCollapse);
     registerWindow();
 
-    ImGui::Begin("Console", &keepWindow, ImGuiWindowFlags_NoCollapse);
+    ImGui::Begin("Console", &keepWindow,
+                 ImGuiWindowFlags_NoCollapse |
+                     ImGuiWindowFlags_NoScrollbar |
+                     ImGuiWindowFlags_NoScrollWithMouse);
     consoleWindow();
 
     ImGui::End();

--- a/src/app/integration/debugBackend.cpp
+++ b/src/app/integration/debugBackend.cpp
@@ -3,6 +3,30 @@
 #include "interpreter/interpreter.hpp"
 #include "../../../vendor/icicle-cpp/icicle.h"
 
+namespace {
+
+MemoryProtection remoteProtection(const remote_gdb::RemoteMemoryRegion& region)
+{
+    if (region.read && region.write && region.execute) {
+        return ExecuteReadWrite;
+    }
+    if (region.read && region.write) {
+        return ReadWrite;
+    }
+    if (region.read && region.execute) {
+        return ExecuteRead;
+    }
+    if (region.execute) {
+        return ExecuteOnly;
+    }
+    if (region.read) {
+        return ReadOnly;
+    }
+    return NoAccess;
+}
+
+}
+
 std::optional<std::vector<uint8_t>> readDebugMemory(const uint64_t address, const size_t size)
 {
     if (remote_gdb::useRemoteDebugging()) {
@@ -28,4 +52,43 @@ bool writeDebugMemory(const uint64_t address, const uint8_t byte)
 
     if (!icicle) return false;
     return icicle_mem_write(icicle, address, &byte, 1) != -1;
+}
+
+std::vector<MemRegionInfo> debugMemoryRegions()
+{
+    if (remote_gdb::useRemoteDebugging()) {
+        std::vector<MemRegionInfo> regions;
+        for (const auto& region : remote_gdb::remoteMemoryRegions()) {
+            regions.push_back({region.start, region.end - region.start, remoteProtection(region)});
+        }
+        return regions;
+    }
+
+    if (!icicle) return {};
+
+    size_t count = 0;
+    MemRegionInfo* rawRegions = icicle_mem_list_mapped(icicle, &count);
+    if (!rawRegions) return {};
+
+    std::vector<MemRegionInfo> regions(rawRegions, rawRegions + count);
+    icicle_mem_list_mapped_free(rawRegions, count);
+    return regions;
+}
+
+bool protectDebugMemory(const uint64_t address, const size_t size, const MemoryProtection protection)
+{
+    if (remote_gdb::useRemoteDebugging() || !icicle) return false;
+    return icicle_mem_protect(icicle, address, size, protection) == 0;
+}
+
+bool mapDebugMemory(const uint64_t address, const size_t size, const MemoryProtection protection)
+{
+    if (remote_gdb::useRemoteDebugging() || !icicle) return false;
+    return icicle_mem_map(icicle, address, size, protection) == 0;
+}
+
+bool unmapDebugMemory(const uint64_t address, const size_t size)
+{
+    if (remote_gdb::useRemoteDebugging() || !icicle) return false;
+    return icicle_mem_unmap(icicle, address, size) == 0;
 }

--- a/src/app/integration/debugBackend.hpp
+++ b/src/app/integration/debugBackend.hpp
@@ -4,6 +4,11 @@
 #include <cstddef>
 #include <optional>
 #include <vector>
+#include "icicle.h"
 
 std::optional<std::vector<uint8_t>> readDebugMemory(uint64_t address, size_t size);
 bool writeDebugMemory(uint64_t address, uint8_t byte);
+std::vector<MemRegionInfo> debugMemoryRegions();
+bool protectDebugMemory(uint64_t address, size_t size, MemoryProtection protection);
+bool mapDebugMemory(uint64_t address, size_t size, MemoryProtection protection);
+bool unmapDebugMemory(uint64_t address, size_t size);

--- a/src/app/integration/gdb/elfSymbols.cpp
+++ b/src/app/integration/gdb/elfSymbols.cpp
@@ -18,9 +18,28 @@ ElfSymbols loadElfSymbols(const std::string&) {
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include <cstddef>
 #include <cstring>
 
 namespace remote_gdb {
+
+namespace {
+
+bool rangeInFile(const uint64_t offset, const uint64_t size, const size_t fileSize) {
+    return offset <= fileSize && size <= fileSize - offset;
+}
+
+const char* boundedString(const char* table, const uint64_t tableSize, const uint64_t offset) {
+    if (offset >= tableSize) {
+        return nullptr;
+    }
+
+    const char* start = table + offset;
+    const void* terminator = std::memchr(start, '\0', static_cast<size_t>(tableSize - offset));
+    return terminator ? start : nullptr;
+}
+
+}
 
 ElfSymbols loadElfSymbols(const std::string& path) {
     ElfSymbols result;
@@ -34,32 +53,85 @@ ElfSymbols loadElfSymbols(const std::string& path) {
         return result;
     }
 
-    void* data = mmap(nullptr, static_cast<size_t>(st.st_size), PROT_READ, MAP_PRIVATE, fd, 0);
-    close(fd);
-    if (data == MAP_FAILED) return result;
-
-    auto* ehdr = reinterpret_cast<Elf64_Ehdr*>(data);
-    if (std::memcmp(ehdr->e_ident, ELFMAG, SELFMAG) != 0) {
-        munmap(data, static_cast<size_t>(st.st_size));
+    const auto fileSize = static_cast<size_t>(st.st_size);
+    if (fileSize < EI_NIDENT) {
+        close(fd);
         return result;
     }
 
-    const bool is64 = (ehdr->e_ident[EI_CLASS] == ELFCLASS64);
+    void* data = mmap(nullptr, fileSize, PROT_READ, MAP_PRIVATE, fd, 0);
+    close(fd);
+    if (data == MAP_FAILED) return result;
+
+    const auto* ident = static_cast<const unsigned char*>(data);
+    if (std::memcmp(ident, ELFMAG, SELFMAG) != 0) {
+        munmap(data, fileSize);
+        return result;
+    }
+
+    const bool is64 = (ident[EI_CLASS] == ELFCLASS64);
+    if (!is64 && ident[EI_CLASS] != ELFCLASS32) {
+        munmap(data, fileSize);
+        return result;
+    }
+
     const char* shstrtab = nullptr;
+    uint64_t shstrtabSize = 0;
     size_t shnum = 0;
     void* shdrBase = nullptr;
 
     if (is64) {
+        if (fileSize < sizeof(Elf64_Ehdr)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
+        auto* ehdr = reinterpret_cast<Elf64_Ehdr*>(data);
+        if (ehdr->e_shentsize < sizeof(Elf64_Shdr) ||
+            ehdr->e_shstrndx == SHN_UNDEF ||
+            ehdr->e_shstrndx >= ehdr->e_shnum ||
+            !rangeInFile(ehdr->e_shoff, static_cast<uint64_t>(ehdr->e_shnum) * ehdr->e_shentsize, fileSize)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
         shdrBase = reinterpret_cast<char*>(data) + ehdr->e_shoff;
         shnum = ehdr->e_shnum;
         auto* shdr = reinterpret_cast<Elf64_Shdr*>(shdrBase);
-        shstrtab = reinterpret_cast<const char*>(data) + shdr[ehdr->e_shstrndx].sh_offset;
+        const auto& shstr = shdr[ehdr->e_shstrndx];
+        if (!rangeInFile(shstr.sh_offset, shstr.sh_size, fileSize)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
+        shstrtab = reinterpret_cast<const char*>(data) + shstr.sh_offset;
+        shstrtabSize = shstr.sh_size;
     } else {
+        if (fileSize < sizeof(Elf32_Ehdr)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
         auto* ehdr32 = reinterpret_cast<Elf32_Ehdr*>(data);
+        if (ehdr32->e_shentsize < sizeof(Elf32_Shdr) ||
+            ehdr32->e_shstrndx == SHN_UNDEF ||
+            ehdr32->e_shstrndx >= ehdr32->e_shnum ||
+            !rangeInFile(ehdr32->e_shoff, static_cast<uint64_t>(ehdr32->e_shnum) * ehdr32->e_shentsize, fileSize)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
         shdrBase = reinterpret_cast<char*>(data) + ehdr32->e_shoff;
         shnum = ehdr32->e_shnum;
         auto* shdr = reinterpret_cast<Elf32_Shdr*>(shdrBase);
-        shstrtab = reinterpret_cast<const char*>(data) + shdr[ehdr32->e_shstrndx].sh_offset;
+        const auto& shstr = shdr[ehdr32->e_shstrndx];
+        if (!rangeInFile(shstr.sh_offset, shstr.sh_size, fileSize)) {
+            munmap(data, fileSize);
+            return result;
+        }
+
+        shstrtab = reinterpret_cast<const char*>(data) + shstr.sh_offset;
+        shstrtabSize = shstr.sh_size;
     }
 
     for (size_t i = 0; i < shnum; ++i) {
@@ -71,35 +143,48 @@ ElfSymbols loadElfSymbols(const std::string& path) {
 
         if (is64) {
             auto* shdr = reinterpret_cast<Elf64_Shdr*>(shdrBase);
-            secName = shstrtab + shdr[i].sh_name;
+            secName = boundedString(shstrtab, shstrtabSize, shdr[i].sh_name);
             secSize = shdr[i].sh_size;
             secOff  = shdr[i].sh_offset;
             secEntsize = shdr[i].sh_entsize;
             secLink = shdr[i].sh_link;
         } else {
             auto* shdr = reinterpret_cast<Elf32_Shdr*>(shdrBase);
-            secName = shstrtab + shdr[i].sh_name;
+            secName = boundedString(shstrtab, shstrtabSize, shdr[i].sh_name);
             secSize = shdr[i].sh_size;
             secOff  = shdr[i].sh_offset;
             secEntsize = shdr[i].sh_entsize;
             secLink = shdr[i].sh_link;
         }
 
+        if (secName == nullptr) continue;
         if (std::strcmp(secName, ".symtab") != 0 && std::strcmp(secName, ".dynsym") != 0) continue;
+        if (secLink >= shnum || !rangeInFile(secOff, secSize, fileSize)) continue;
 
         const char* strtab = nullptr;
+        uint64_t strtabSize = 0;
         if (is64) {
             auto* shdr = reinterpret_cast<Elf64_Shdr*>(shdrBase);
+            if (!rangeInFile(shdr[secLink].sh_offset, shdr[secLink].sh_size, fileSize)) continue;
             strtab = reinterpret_cast<const char*>(data) + shdr[secLink].sh_offset;
+            strtabSize = shdr[secLink].sh_size;
         } else {
             auto* shdr = reinterpret_cast<Elf32_Shdr*>(shdrBase);
+            if (!rangeInFile(shdr[secLink].sh_offset, shdr[secLink].sh_size, fileSize)) continue;
             strtab = reinterpret_cast<const char*>(data) + shdr[secLink].sh_offset;
+            strtabSize = shdr[secLink].sh_size;
         }
 
+        const size_t minEntrySize = is64 ? sizeof(Elf64_Sym) : sizeof(Elf32_Sym);
+        if (secEntsize < minEntrySize) continue;
+
         const size_t count = secEntsize > 0 ? secSize / secEntsize : 0;
-        auto* symBase = reinterpret_cast<char*>(data) + secOff;
+        auto* symBase = reinterpret_cast<const char*>(data) + secOff;
 
         for (size_t j = 0; j < count; ++j) {
+            const uint64_t entryOffset = secOff + (j * secEntsize);
+            if (!rangeInFile(entryOffset, minEntrySize, fileSize)) continue;
+
             uint64_t symVal = 0;
             uint64_t symSizeVal = 0;
             uint8_t symType = 0;
@@ -107,19 +192,19 @@ ElfSymbols loadElfSymbols(const std::string& path) {
             const char* symName = nullptr;
 
             if (is64) {
-                auto* sym = reinterpret_cast<Elf64_Sym*>(symBase) + j;
+                auto* sym = reinterpret_cast<const Elf64_Sym*>(symBase + (j * secEntsize));
                 symVal  = sym->st_value;
                 symSizeVal = sym->st_size;
                 symType = ELF64_ST_TYPE(sym->st_info);
                 symShndx = sym->st_shndx;
-                if (sym->st_name > 0) symName = strtab + sym->st_name;
+                if (sym->st_name > 0) symName = boundedString(strtab, strtabSize, sym->st_name);
             } else {
-                auto* sym = reinterpret_cast<Elf32_Sym*>(symBase) + j;
+                auto* sym = reinterpret_cast<const Elf32_Sym*>(symBase + (j * secEntsize));
                 symVal  = sym->st_value;
                 symSizeVal = sym->st_size;
                 symType = ELF32_ST_TYPE(sym->st_info);
                 symShndx = sym->st_shndx;
-                if (sym->st_name > 0) symName = strtab + sym->st_name;
+                if (sym->st_name > 0) symName = boundedString(strtab, strtabSize, sym->st_name);
             }
 
             if (symVal == 0 || symShndx == SHN_UNDEF || symName == nullptr) continue;
@@ -131,7 +216,7 @@ ElfSymbols loadElfSymbols(const std::string& path) {
         }
     }
 
-    munmap(data, static_cast<size_t>(st.st_size));
+    munmap(data, fileSize);
     return result;
 }
 

--- a/src/app/integration/gdb/elfSymbols.cpp
+++ b/src/app/integration/gdb/elfSymbols.cpp
@@ -87,7 +87,7 @@ ElfSymbols loadElfSymbols(const std::string& path) {
         }
 
         auto* ehdr = reinterpret_cast<Elf64_Ehdr*>(data);
-        if (ehdr->e_shentsize < sizeof(Elf64_Shdr) ||
+        if (ehdr->e_shentsize != sizeof(Elf64_Shdr) ||
             ehdr->e_shstrndx == SHN_UNDEF ||
             ehdr->e_shstrndx >= ehdr->e_shnum ||
             !rangeInFile(ehdr->e_shoff, static_cast<uint64_t>(ehdr->e_shnum) * ehdr->e_shentsize, fileSize)) {
@@ -113,7 +113,7 @@ ElfSymbols loadElfSymbols(const std::string& path) {
         }
 
         auto* ehdr32 = reinterpret_cast<Elf32_Ehdr*>(data);
-        if (ehdr32->e_shentsize < sizeof(Elf32_Shdr) ||
+        if (ehdr32->e_shentsize != sizeof(Elf32_Shdr) ||
             ehdr32->e_shstrndx == SHN_UNDEF ||
             ehdr32->e_shstrndx >= ehdr32->e_shnum ||
             !rangeInFile(ehdr32->e_shoff, static_cast<uint64_t>(ehdr32->e_shnum) * ehdr32->e_shentsize, fileSize)) {

--- a/src/app/integration/gdb/gdbPacket.cpp
+++ b/src/app/integration/gdb/gdbPacket.cpp
@@ -1,0 +1,95 @@
+#include "gdbPacket.hpp"
+
+#include <cctype>
+#include <charconv>
+
+namespace remote_gdb {
+
+std::string formatHexByte(const uint8_t byte) {
+    constexpr char digits[] = "0123456789abcdef";
+    std::string out(2, '0');
+    out[0] = digits[(byte >> 4) & 0xf];
+    out[1] = digits[byte & 0xf];
+    return out;
+}
+
+std::string encodeHex(std::string_view input) {
+    std::string out;
+    out.reserve(input.size() * 2);
+    for (const auto ch : input) {
+        out += formatHexByte(static_cast<uint8_t>(ch));
+    }
+    return out;
+}
+
+std::string encodeHex(const std::vector<uint8_t>& input) {
+    std::string out;
+    out.reserve(input.size() * 2);
+    for (const auto byte : input) {
+        out += formatHexByte(byte);
+    }
+    return out;
+}
+
+std::optional<std::vector<uint8_t>> decodeHexBytes(std::string_view input) {
+    std::string expanded;
+    expanded.reserve(input.size());
+    for (size_t i = 0; i < input.size(); ++i) {
+        const auto ch = input[i];
+        if (ch == '*' && !expanded.empty() && (i + 1) < input.size()) {
+            const int repeatCount = static_cast<unsigned char>(input[++i]) - 29;
+            if (repeatCount < 3 || repeatCount > 97) {
+                return std::nullopt;
+            }
+            expanded.append(static_cast<size_t>(repeatCount), expanded.back());
+            continue;
+        }
+        expanded.push_back(ch);
+    }
+    input = expanded;
+
+    if ((input.size() % 2) != 0) {
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> out;
+    out.reserve(input.size() / 2);
+    for (size_t i = 0; i < input.size(); i += 2) {
+        const auto hi = input.substr(i, 2);
+        unsigned int value = 0;
+        auto result = std::from_chars(hi.data(), hi.data() + hi.size(), value, 16);
+        if (result.ec != std::errc{}) {
+            return std::nullopt;
+        }
+        out.push_back(static_cast<uint8_t>(value));
+    }
+
+    return out;
+}
+
+bool isHexString(std::string_view input) {
+    for (const auto ch : input) {
+        if (!std::isxdigit(static_cast<unsigned char>(ch))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+std::string decodeHexText(std::string_view input) {
+    const auto bytes = decodeHexBytes(input);
+    if (!bytes.has_value()) {
+        return {};
+    }
+    return {bytes->begin(), bytes->end()};
+}
+
+uint8_t packetChecksum(std::string_view payload) {
+    uint8_t checksum = 0;
+    for (const auto ch : payload) {
+        checksum = static_cast<uint8_t>(checksum + static_cast<uint8_t>(ch));
+    }
+    return checksum;
+}
+
+}

--- a/src/app/integration/gdb/gdbPacket.hpp
+++ b/src/app/integration/gdb/gdbPacket.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace remote_gdb {
+
+std::string formatHexByte(uint8_t byte);
+std::string encodeHex(std::string_view input);
+std::string encodeHex(const std::vector<uint8_t>& input);
+std::optional<std::vector<uint8_t>> decodeHexBytes(std::string_view input);
+bool isHexString(std::string_view input);
+std::string decodeHexText(std::string_view input);
+uint8_t packetChecksum(std::string_view payload);
+
+}

--- a/src/app/integration/gdb/gdbRemote.cpp
+++ b/src/app/integration/gdb/gdbRemote.cpp
@@ -460,6 +460,7 @@ bool GdbRemoteClient::connectTo(const RemoteConnectionConfig& config) {
         disconnect();
         return false;
     }
+    clearSocketTimeout(socket_);
     return true;
 }
 

--- a/src/app/integration/gdb/gdbRemote.cpp
+++ b/src/app/integration/gdb/gdbRemote.cpp
@@ -42,6 +42,9 @@ namespace {
 
 RemoteLogSink g_logSink;
 RemoteArchHook g_archHook;
+constexpr size_t kMaxPacketPayloadSize = 16 * 1024 * 1024;
+constexpr size_t kMaxSkippedPacketBytes = 4096;
+constexpr size_t kMaxChecksumFailures = 3;
 
 void log(const std::string& text) {
     if (g_logSink) g_logSink(text);
@@ -457,7 +460,6 @@ bool GdbRemoteClient::connectTo(const RemoteConnectionConfig& config) {
         disconnect();
         return false;
     }
-    clearSocketTimeout(socket_);
     return true;
 }
 
@@ -526,17 +528,21 @@ bool GdbRemoteClient::readPacket(std::string& payload) {
         return false;
     }
 
-    while (true) {
+    size_t skippedBytes = 0;
+    size_t checksumFailures = 0;
+    while (skippedBytes < kMaxSkippedPacketBytes && checksumFailures < kMaxChecksumFailures) {
         char ch = '\0';
         if (!recvByte(socket_, ch)) {
             return false;
         }
 
         if (ch == '+' || ch == '-') {
+            ++skippedBytes;
             continue;
         }
 
         if (ch != '$') {
+            ++skippedBytes;
             if (static_cast<unsigned char>(ch) == 0x03) {
                 continue;
             }
@@ -552,6 +558,10 @@ bool GdbRemoteClient::readPacket(std::string& payload) {
                 break;
             }
             packet.push_back(ch);
+            if (packet.size() > kMaxPacketPayloadSize) {
+                log("remote >> packet payload exceeded size limit\n");
+                return false;
+            }
         }
 
         std::array<char, 2> checksumChars{};
@@ -562,6 +572,7 @@ bool GdbRemoteClient::readPacket(std::string& payload) {
         unsigned int expected = 0;
         auto parse = std::from_chars(checksumChars.data(), checksumChars.data() + checksumChars.size(), expected, 16);
         if (parse.ec != std::errc{} || static_cast<uint8_t>(expected) != packetChecksum(packet)) {
+            ++checksumFailures;
             if (!noAckMode_) {
                 sendAll(socket_, "-");
             }
@@ -571,6 +582,8 @@ bool GdbRemoteClient::readPacket(std::string& payload) {
         if (!noAckMode_) {
             sendAll(socket_, "+");
         }
+        checksumFailures = 0;
+        skippedBytes = 0;
 
         if (!packet.empty() && packet[0] == 'O' &&
             ((packet.size() - 1) % 2 == 0) &&
@@ -582,6 +595,9 @@ bool GdbRemoteClient::readPacket(std::string& payload) {
         payload = std::move(packet);
         return true;
     }
+
+    log("remote >> packet read aborted after repeated invalid data\n");
+    return false;
 }
 
 void GdbRemoteClient::teardownSocket() {

--- a/src/app/integration/gdb/gdbRemote.cpp
+++ b/src/app/integration/gdb/gdbRemote.cpp
@@ -1,4 +1,5 @@
 #include "gdbRemote.hpp"
+#include "gdbPacket.hpp"
 
 #include <algorithm>
 #include <array>
@@ -65,93 +66,6 @@ struct DecodedInstruction {
     bool isCall = false;
     std::string mnemonic;
 };
-
-std::string formatHexByte(uint8_t byte) {
-    constexpr char digits[] = "0123456789abcdef";
-    std::string out(2, '0');
-    out[0] = digits[(byte >> 4) & 0xf];
-    out[1] = digits[byte & 0xf];
-    return out;
-}
-
-std::string encodeHex(std::string_view input) {
-    std::string out;
-    out.reserve(input.size() * 2);
-    for (const auto ch : input) {
-        out += formatHexByte(static_cast<uint8_t>(ch));
-    }
-    return out;
-}
-
-std::string encodeHex(const std::vector<uint8_t>& input) {
-    std::string out;
-    out.reserve(input.size() * 2);
-    for (const auto byte : input) {
-        out += formatHexByte(byte);
-    }
-    return out;
-}
-
-std::optional<std::vector<uint8_t>> decodeHexBytes(std::string_view input) {
-    std::string expanded;
-    expanded.reserve(input.size());
-    for (size_t i = 0; i < input.size(); ++i) {
-        const auto ch = input[i];
-        if (ch == '*' && !expanded.empty() && (i + 1) < input.size()) {
-            const int repeatCount = static_cast<unsigned char>(input[++i]) - 29;
-            if (repeatCount < 3 || repeatCount > 97) {
-                return std::nullopt;
-            }
-            expanded.append(static_cast<size_t>(repeatCount), expanded.back());
-            continue;
-        }
-        expanded.push_back(ch);
-    }
-    input = expanded;
-
-    if ((input.size() % 2) != 0) {
-        return std::nullopt;
-    }
-
-    std::vector<uint8_t> out;
-    out.reserve(input.size() / 2);
-    for (size_t i = 0; i < input.size(); i += 2) {
-        const auto hi = input.substr(i, 2);
-        unsigned int value = 0;
-        auto result = std::from_chars(hi.data(), hi.data() + hi.size(), value, 16);
-        if (result.ec != std::errc{}) {
-            return std::nullopt;
-        }
-        out.push_back(static_cast<uint8_t>(value));
-    }
-
-    return out;
-}
-
-bool isHexString(std::string_view input) {
-    for (const auto ch : input) {
-        if (!std::isxdigit(static_cast<unsigned char>(ch))) {
-            return false;
-        }
-    }
-    return true;
-}
-
-std::string decodeHexText(std::string_view input) {
-    const auto bytes = decodeHexBytes(input);
-    if (!bytes.has_value()) {
-        return {};
-    }
-    return {bytes->begin(), bytes->end()};
-}
-
-uint8_t packetChecksum(std::string_view payload) {
-    uint8_t checksum = 0;
-    for (const auto ch : payload) {
-        checksum = static_cast<uint8_t>(checksum + static_cast<uint8_t>(ch));
-    }
-    return checksum;
-}
 
 void closeSocket(socket_handle_t handle) {
     if (handle == invalid_socket_handle) {

--- a/src/app/integration/interpreter/breakpoints.cpp
+++ b/src/app/integration/interpreter/breakpoints.cpp
@@ -1,11 +1,10 @@
 #include "interpreter.hpp"
 
 bool removeBreakpoint(const uint64_t& address) {
-    breakpointMutex.lock();
+    std::lock_guard<std::mutex> lock(breakpointMutex);
 
     bool success = false;
     if (breakpointLines.empty()) {
-        breakpointMutex.unlock();
         return success;
     }
 
@@ -16,12 +15,11 @@ bool removeBreakpoint(const uint64_t& address) {
         success = true;
     }
 
-    breakpointMutex.unlock();
     return success;
 }
 
 bool removeBreakpointFromLineNo(const uint64_t& lineNo) {
-    breakpointMutex.lock();
+    std::lock_guard<std::mutex> lock(breakpointMutex);
     bool success = false;
 
     if (isSilentBreakpoint(lineNo))
@@ -32,13 +30,12 @@ bool removeBreakpointFromLineNo(const uint64_t& lineNo) {
     }
 
     if (breakpointLines.empty()) {
-        breakpointMutex.unlock();
         return success;
     }
 
     const auto it = std::ranges::find(breakpointLines, lineNo);
     size_t size;
-    const uint64_t* bpList = icicle_breakpoint_list(icicle, &size);
+    uint64_t* bpList = icicle_breakpoint_list(icicle, &size);
 
     if (bpList)
     {
@@ -54,10 +51,8 @@ bool removeBreakpointFromLineNo(const uint64_t& lineNo) {
                 break;
             }
         }
+        icicle_breakpoint_list_free(bpList, size);
     }
-
-
-    breakpointMutex.unlock();
 
     return success;
 }

--- a/src/app/integration/interpreter/execution.cpp
+++ b/src/app/integration/interpreter/execution.cpp
@@ -25,10 +25,16 @@ int handleSyscalls(void* data, uint64_t syscall_nr, const SyscallArgs* args)
         if (syscall_nr == 1)
         {
             LOG_DEBUG("Write syscall requested!");
-            size_t r;
-            auto s = icicle_mem_read((Icicle*)data, args->arg1, args->arg2, &r);
-            s[args->arg2] = '\0';
-            std::string j(reinterpret_cast<const char*>(s));
+            size_t outSize = 0;
+            auto s = icicle_mem_read(static_cast<Icicle*>(data), args->arg1, args->arg2, &outSize);
+            if (!s)
+            {
+                LOG_ERROR("Failed to read syscall write buffer.");
+                return 0;
+            }
+
+            std::string j(reinterpret_cast<const char*>(s), outSize);
+            icicle_free_buffer(s, outSize);
             consoleWriteThreadSafe("stdout >> " + j + "\n");
         }
         else if (syscall_nr == 60)
@@ -46,28 +52,30 @@ void instructionHook(void* userData, const uint64_t address)
     if (lineNo > 0)
         safeHighlightLine(lineNo - 1);
 
+    if (ttdEnabled)
+    {
+        if (!snapshot)
+        {
+            snapshot = icicle_vm_snapshot(icicle);
+            return;
+        }
+
+        if (vmSnapshots.empty() || vmSnapshots.top() != snapshot)
+        {
+            vmSnapshots.push(snapshot);
+        }
+
+        snapshot = icicle_vm_snapshot(icicle);
+        if (!snapshot)
+        {
+            LOG_ERROR("Failed to save VM snapshot for time-travel debugging.");
+        }
+        return;
+    }
 
     if (!snapshot)
     {
         snapshot = icicle_vm_snapshot(icicle);
-        if (ttdEnabled)
-            vmSnapshots.push(snapshot);
-    }
-    else
-    {
-        if (ttdEnabled)
-        {
-            if (!vmSnapshots.empty())
-            {
-                if (vmSnapshots.top() == snapshot)
-                {
-                    return;
-                }
-            }
-
-            vmSnapshots.push(snapshot);
-            snapshot = icicle_vm_snapshot(icicle);
-        }
     }
 }
 
@@ -79,24 +87,35 @@ void stackWriteHook(void* data, uint64_t address, uint8_t size, const uint64_t v
 bool preExecutionSetup(const std::string& codeIn)
 {
     initRegistersToDefinedVals();
-    if (codeBuf.empty()){
-        codeBuf.resize(CODE_BUF_SIZE);
-        std::fill(codeBuf.begin(), codeBuf.end(), 0);
+    const auto codeBufferSize = static_cast<size_t>(CODE_BUF_SIZE);
+    if (codeIn.size() > codeBufferSize)
+    {
+        LOG_ERROR("Assembled code is larger than the executable buffer.");
+        return false;
+    }
+
+    if (codeBuf.size() != codeBufferSize){
+        codeBuf.resize(codeBufferSize);
         LOG_DEBUG("Code buffer allocated!");
     }
 
-    const auto *code = (uint8_t *)(codeIn.c_str());
-    std::memcpy(codeBuf.data(), code, codeIn.length());
+    std::fill(codeBuf.begin(), codeBuf.end(), 0);
+    std::memcpy(codeBuf.data(), codeIn.data(), codeIn.size());
 
     // TODO: Add a way to make stack executable
     const auto e = icicle_mem_map(icicle, ENTRY_POINT_ADDRESS, CODE_BUF_SIZE, MemoryProtection::ExecuteReadWrite);
-    if (e == -1)
+    if (e != 0)
     {
         LOG_ERROR("Failed to map memory for writing code!");
         return false;
     }
 
-    auto k = icicle_mem_write(icicle, ENTRY_POINT_ADDRESS, codeBuf.data(), CODE_BUF_SIZE - 1);
+    auto k = icicle_mem_write(icicle, ENTRY_POINT_ADDRESS, codeBuf.data(), codeBufferSize);
+    if (k != 0)
+    {
+        LOG_ERROR("Failed to write code into executable memory.");
+        return false;
+    }
     icicle_set_pc(icicle, ENTRY_POINT_ADDRESS);
 
     // Ensure snapshot is taken before signaling ready
@@ -222,6 +241,8 @@ bool executeCode(Icicle* icicle, const size_t& instructionCount)
         return false;
     }
 
+    std::lock_guard<std::recursive_mutex> execLock(execMutex);
+
     if (executionComplete)
     {
         LOG_ALERT("Attempt to execute code after the code is completely executed. Ignoring.");
@@ -305,6 +326,8 @@ bool stepCode(const size_t instructionCount){
     }
     LOG_DEBUG("Debug state confirmed ready, proceeding with step.");
 
+    std::lock_guard<std::recursive_mutex> execLock(execMutex);
+
     if (isCodeRunning || executionComplete){
         LOG_DEBUG("Step request ignored: Code already running or execution complete.");
         return true;
@@ -323,11 +346,11 @@ bool stepCode(const size_t instructionCount){
 
     // Update state *after* execution
     ip = icicle_get_pc(icicle);
-    editor->HighlightDebugCurrentLine(addressLineNoMap[icicle_get_pc(icicle)]);
+    safeHighlightLine(addressLineNoMap[icicle_get_pc(icicle)]);
     isCodeRunning = false; // Mark as not running *after* execution
 
     if (executionComplete){
-        editor->HighlightDebugCurrentLine(lastInstructionLineNo-1);
+        safeHighlightLine(lastInstructionLineNo-1);
         LOG_DEBUG("Execution complete after step.");
         return true;
     }
@@ -354,7 +377,7 @@ bool stepCode(const size_t instructionCount){
         const uint64_t lineNo =  addressLineNoMap[ip];
         if (lineNo && !executionComplete){
             LOG_DEBUG("Highlight from stepCode : line: " << lineNo);
-            editor->HighlightDebugCurrentLine(lineNo - 1);
+            safeHighlightLine(lineNo - 1);
         }
         else{
              LOG_DEBUG("No line number found for current IP or execution complete.");
@@ -379,6 +402,8 @@ bool stepCode(const size_t instructionCount){
 bool runCode(const std::string& codeIn, const bool& execCode)
 {
     LOG_INFO("Running code...");
+    std::lock_guard<std::recursive_mutex> execLock(execMutex);
+
     if (!preExecutionSetup(codeIn)) {
         return false;
     }
@@ -388,8 +413,7 @@ bool runCode(const std::string& codeIn, const bool& execCode)
     if (!val)
         val = 1;
 
-
-    editor->HighlightDebugCurrentLine(val - 1);
+    safeHighlightLine(val - 1);
 
     if (execCode || (stepClickedOnce)){
         if (addBreakpointToLine(lastInstructionLineNo, true))
@@ -402,7 +426,7 @@ bool runCode(const std::string& codeIn, const bool& execCode)
             LOG_ERROR("Failed to run code.");
         }
 
-        editor->HighlightDebugCurrentLine(lastInstructionLineNo);
+        safeHighlightLine(lastInstructionLineNo);
         if (runningTempCode){
             // icicle_vm_snapshot(icicle);
             updateRegs();
@@ -421,8 +445,7 @@ bool runCode(const std::string& codeIn, const bool& execCode)
         if (!val)
             val = 1;
 
-
-        editor->HighlightDebugCurrentLine(val - 1);
+        safeHighlightLine(val - 1);
         LOG_DEBUG("Highlight from runCode");
         stepClickedOnce = true;
     }

--- a/src/app/integration/interpreter/execution.cpp
+++ b/src/app/integration/interpreter/execution.cpp
@@ -84,6 +84,8 @@ void stackWriteHook(void* data, uint64_t address, uint8_t size, const uint64_t v
     updateStack = true;
 }
 
+static bool executeCodeCore(Icicle* icicle, const size_t& instructionCount);
+
 bool preExecutionSetup(const std::string& codeIn)
 {
     initRegistersToDefinedVals();
@@ -200,7 +202,7 @@ bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, co
                 // This doesn't have to be done for continues though
                 if (instructionCount == 1)
                 {
-                    executeCode(icicle, 1);
+                    executeCodeCore(icicle, 1);
                 }
             }
         }
@@ -233,15 +235,13 @@ bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, co
     return true;
 }
 
-bool executeCode(Icicle* icicle, const size_t& instructionCount)
+static bool executeCodeCore(Icicle* icicle, const size_t& instructionCount)
 {
     if (icicle == nullptr)
     {
         LOG_ERROR("Attempted to run code when icicle was not initialised!");
         return false;
     }
-
-    std::lock_guard<std::recursive_mutex> execLock(execMutex);
 
     if (executionComplete)
     {
@@ -317,6 +317,12 @@ bool executeCode(Icicle* icicle, const size_t& instructionCount)
     return checkStatusUpdateState(instructionCount, status, currentInstrAddr);
 }
 
+bool executeCode(Icicle* icicle, const size_t& instructionCount)
+{
+    std::lock_guard<std::mutex> execLock(execMutex);
+    return executeCodeCore(icicle, instructionCount);
+}
+
 bool stepCode(const size_t instructionCount){
     LOG_DEBUG("Stepping into code requested...");
 
@@ -326,7 +332,7 @@ bool stepCode(const size_t instructionCount){
     }
     LOG_DEBUG("Debug state confirmed ready, proceeding with step.");
 
-    std::lock_guard<std::recursive_mutex> execLock(execMutex);
+    std::lock_guard<std::mutex> execLock(execMutex);
 
     if (isCodeRunning || executionComplete){
         LOG_DEBUG("Step request ignored: Code already running or execution complete.");
@@ -342,7 +348,7 @@ bool stepCode(const size_t instructionCount){
     size_t siz{};
     RunStatus status{};
 
-    executeCode(icicle, instructionCount); // This contains the core execution
+    executeCodeCore(icicle, instructionCount); // This contains the core execution
 
     // Update state *after* execution
     ip = icicle_get_pc(icicle);
@@ -402,7 +408,7 @@ bool stepCode(const size_t instructionCount){
 bool runCode(const std::string& codeIn, const bool& execCode)
 {
     LOG_INFO("Running code...");
-    std::lock_guard<std::recursive_mutex> execLock(execMutex);
+    std::lock_guard<std::mutex> execLock(execMutex);
 
     if (!preExecutionSetup(codeIn)) {
         return false;
@@ -421,7 +427,7 @@ bool runCode(const std::string& codeIn, const bool& execCode)
             isEndBreakpointSet = true;
         }
 
-        if (!executeCode(icicle, 0))
+        if (!executeCodeCore(icicle, 0))
         {
             LOG_ERROR("Failed to run code.");
         }

--- a/src/app/integration/interpreter/interpreter.cpp
+++ b/src/app/integration/interpreter/interpreter.cpp
@@ -21,7 +21,7 @@ uint64_t lineNo = 1;
 uint64_t expectedIP = 0;
 int stepOverBPLineNo = -1;
 
-std::mutex execMutex;
+std::recursive_mutex execMutex;
 std::mutex breakpointMutex;
 std::mutex criticalSection{};
 

--- a/src/app/integration/interpreter/interpreter.cpp
+++ b/src/app/integration/interpreter/interpreter.cpp
@@ -21,7 +21,7 @@ uint64_t lineNo = 1;
 uint64_t expectedIP = 0;
 int stepOverBPLineNo = -1;
 
-std::recursive_mutex execMutex;
+std::mutex execMutex;
 std::mutex breakpointMutex;
 std::mutex criticalSection{};
 

--- a/src/app/integration/interpreter/interpreter.hpp
+++ b/src/app/integration/interpreter/interpreter.hpp
@@ -87,7 +87,7 @@ typedef struct{
 } registerValueInfoT;
 
 extern VmSnapshot* saveICSnapshot(Icicle* icicle);
-extern std::mutex execMutex;
+extern std::recursive_mutex execMutex;
 extern std::mutex breakpointMutex;
 extern bool skipBreakpoints;
 extern bool runningAsContinue;

--- a/src/app/integration/interpreter/interpreter.hpp
+++ b/src/app/integration/interpreter/interpreter.hpp
@@ -87,7 +87,7 @@ typedef struct{
 } registerValueInfoT;
 
 extern VmSnapshot* saveICSnapshot(Icicle* icicle);
-extern std::recursive_mutex execMutex;
+extern std::mutex execMutex;
 extern std::mutex breakpointMutex;
 extern bool skipBreakpoints;
 extern bool runningAsContinue;

--- a/src/app/integration/interpreter/registers.cpp
+++ b/src/app/integration/interpreter/registers.cpp
@@ -1,4 +1,21 @@
 #include "interpreter.hpp"
+#include <optional>
+
+static std::optional<size_t> registerBitSize(const std::string& regName)
+{
+    if (const auto it = regInfoMap.find(regName); it != regInfoMap.end())
+    {
+        return it->second;
+    }
+
+    const auto lowerRegName = toLowerCase(regName);
+    if (const auto it = regInfoMap.find(lowerRegName); it != regInfoMap.end())
+    {
+        return it->second;
+    }
+
+    return std::nullopt;
+}
 
 std::pair<float, float> convert64BitToTwoFloats(const uint64_t bits) {
     float lower_float, upper_float;
@@ -29,7 +46,14 @@ static uint64_t readLittleEndianInteger(const std::vector<uint8_t>& bytes) {
 
 static registerValueT decodeRemoteRegisterValue(const std::string& regName,
                                                 const std::vector<uint8_t>& bytes) {
-    const auto size = regInfoMap[regName];
+    const auto sizeOpt = registerBitSize(regName);
+    if (!sizeOpt.has_value())
+    {
+        LOG_ERROR("Unknown register " << regName);
+        return {.eightByteVal = 0};
+    }
+
+    const auto size = *sizeOpt;
     const auto lowerRegName = toLowerCase(regName);
     const bool isX86 = (codeInformation.archIC == IC_ARCH_X86_64 || codeInformation.archIC == IC_ARCH_I386);
 
@@ -117,7 +141,14 @@ static registerValueT decodeRemoteRegisterValue(const std::string& regName,
 
 static std::vector<uint8_t> encodeRemoteRegisterValue(const std::string& regName,
                                                       const registerValueT& value) {
-    const auto size = regInfoMap[regName];
+    const auto sizeOpt = registerBitSize(regName);
+    if (!sizeOpt.has_value())
+    {
+        LOG_ERROR("Unknown register " << regName);
+        return {};
+    }
+
+    const auto size = *sizeOpt;
     const auto lowerRegName = toLowerCase(regName);
     const bool isX86 = (codeInformation.archIC == IC_ARCH_X86_64 || codeInformation.archIC == IC_ARCH_I386);
 
@@ -294,7 +325,14 @@ registerValueT read128BitRegisterValue(const std::string& regName)
 }
 
 registerValueT getRegisterValue(const std::string& regName) {
-    const auto size = regInfoMap[regName];
+    const auto sizeOpt = registerBitSize(regName);
+    if (!sizeOpt.has_value())
+    {
+        LOG_ERROR("Unknown register " << regName);
+        return {.eightByteVal = 0};
+    }
+
+    const auto size = *sizeOpt;
     const std::string lowerRegName = toLowerCase(regName);
     const bool isX86 = (codeInformation.archIC == IC_ARCH_X86_64 || codeInformation.archIC == IC_ARCH_I386);
 
@@ -449,7 +487,14 @@ bool write128BitRegisterValue(const std::string& regName, const registerValueT& 
 }
 
 bool setRegisterValue(const std::string& regName, const registerValueT& value) {
-    const auto size = regInfoMap[regName];
+    const auto sizeOpt = registerBitSize(regName);
+    if (!sizeOpt.has_value())
+    {
+        LOG_ERROR("Unknown register " << regName);
+        return false;
+    }
+
+    const auto size = *sizeOpt;
     const std::string lowerRegName = toLowerCase(regName);
     const bool isX86 = (codeInformation.archIC == IC_ARCH_X86_64 || codeInformation.archIC == IC_ARCH_I386);
 
@@ -524,6 +569,11 @@ registerValueInfoT getRegister(const std::string& name){
     if (!codeHasRun){
         constexpr registerValueInfoT ret = {false, 0x00};
         return ret;
+    }
+
+    if (!registerBitSize(regName).has_value())
+    {
+        return res;
     }
 
     const auto value = getRegisterValue(regName);

--- a/src/app/integration/interpreter/vm.cpp
+++ b/src/app/integration/interpreter/vm.cpp
@@ -1,4 +1,33 @@
 #include "interpreter.hpp"
+#include <unordered_set>
+
+namespace {
+
+void freeSnapshotOnce(VmSnapshot* snapshotToFree, std::unordered_set<VmSnapshot*>& freedSnapshots)
+{
+    if (snapshotToFree && freedSnapshots.insert(snapshotToFree).second)
+    {
+        icicle_vm_snapshot_free(snapshotToFree);
+    }
+}
+
+void clearVmSnapshots()
+{
+    std::unordered_set<VmSnapshot*> freedSnapshots;
+    while (!vmSnapshots.empty())
+    {
+        freeSnapshotOnce(vmSnapshots.top(), freedSnapshots);
+        vmSnapshots.pop();
+    }
+
+    freeSnapshotOnce(snapshot, freedSnapshots);
+    snapshot = nullptr;
+
+    freeSnapshotOnce(snapshotLast, freedSnapshots);
+    snapshotLast = nullptr;
+}
+
+}
 
 VmSnapshot* saveICSnapshot(Icicle* icicle){
     if (icicle == nullptr){
@@ -83,7 +112,7 @@ bool createStack(Icicle* ic)
     // Only map if not already mapped
     if (!alreadyMapped) {
         const auto mapped = icicle_mem_map(ic, STACK_ADDRESS, STACK_SIZE, MemoryProtection::ReadWrite);
-        if (mapped == -1)
+        if (mapped != 0)
         {
             LOG_ERROR("Icicle was unable to map memory for the stack.");
             free(zeroBuf);
@@ -92,8 +121,11 @@ bool createStack(Icicle* ic)
         for (uint64_t off = 0; off < STACK_SIZE; off += 0x1000) {
             size_t out = 0;
             // A 1‑byte read is enough to trigger the lazy page allocation
-            const auto s = icicle_mem_read(icicle, STACK_ADDRESS + off, 1, &out);
-            icicle_free_buffer(s, 1);
+            const auto s = icicle_mem_read(ic, STACK_ADDRESS + off, 1, &out);
+            if (s)
+            {
+                icicle_free_buffer(s, out);
+            }
         }
     }
     LOG_INFO("Attempting a mem_write");
@@ -153,6 +185,8 @@ bool resetState(bool reInit){
     }
     restoreLocalEditorAfterRemoteSession();
 
+    clearVmSnapshots();
+
     if (icicle != nullptr)
     {
         icicle_free(icicle);
@@ -163,17 +197,6 @@ bool resetState(bool reInit){
     {
         ks_close(ks);
         ks = nullptr;
-    }
-
-
-    if (!vmSnapshots.empty())
-    {
-        for (int j = 0; j < vmSnapshots.size(); j++)
-        {
-            icicle_vm_snapshot_free(vmSnapshots.top());
-            vmSnapshots.pop();
-        }
-        vmSnapshots = {};
     }
 
     labels.clear();

--- a/src/app/tasks/editorTasks.cpp
+++ b/src/app/tasks/editorTasks.cpp
@@ -1,6 +1,7 @@
 #include "editorTasks.hpp"
 #include "../integration/keystone/assembler.hpp"
 #include "../app.hpp"
+#include <cctype>
 
 TextEditor *editor = nullptr;
 
@@ -191,12 +192,23 @@ std::pair<int, int> parseStrIntoCoordinates(std::string &popupInput) {
 
 std::vector<uint8_t> hexToBytes(const std::string &hex) {
     std::vector<uint8_t> bytes;
-    for (size_t i = 0; i < hex.length(); i += 4) {
-        if (hex[i] == '\\' && hex[i + 1] == 'x') {
-            std::string byteString = hex.substr(i + 2, 2);
-            auto byte = static_cast<uint8_t>(strtol(byteString.c_str(), nullptr, 16));
-            bytes.push_back(byte);
+    for (size_t i = 0; i + 3 < hex.length();) {
+        if (hex[i] != '\\' || hex[i + 1] != 'x') {
+            ++i;
+            continue;
         }
+
+        const auto high = static_cast<unsigned char>(hex[i + 2]);
+        const auto low = static_cast<unsigned char>(hex[i + 3]);
+        if (!std::isxdigit(high) || !std::isxdigit(low)) {
+            i += 2;
+            continue;
+        }
+
+        std::string byteString = hex.substr(i + 2, 2);
+        auto byte = static_cast<uint8_t>(strtol(byteString.c_str(), nullptr, 16));
+        bytes.push_back(byte);
+        i += 4;
     }
     return bytes;
 }
@@ -212,6 +224,11 @@ void pasteCallback(const std::string clipboardText) {
         }
 
         const std::vector<uint8_t> bytes = hexToBytes(clipboardText);
+        if (bytes.empty()) {
+            cs_close(&handle);
+            return;
+        }
+
         const size_t count = cs_disasm(handle, bytes.data(), bytes.size(), ENTRY_POINT_ADDRESS, 0, &instruction);
 
         if (count == 0) {

--- a/src/app/tasks/fileTasks.cpp
+++ b/src/app/tasks/fileTasks.cpp
@@ -108,7 +108,7 @@ bool serializeState()
         return false;
     }
 
-    const char* fileName = tinyfd_saveFileDialog("Select a file to serialize into", NULL, NULL, NULL, NULL);
+    const char* fileName = tinyfd_saveFileDialog("Select a file to serialize into", nullptr, 0, nullptr, nullptr);
     if (!fileName)
     {
         LOG_ERROR("No file selected...");
@@ -135,8 +135,8 @@ bool deserializeState()
         startDebugging();
     }
 
-    const char* fileName = tinyfd_openFileDialog("Select file to deserialize", NULL, NULL, NULL, NULL, NULL);
-    if (fileName == NULL)
+    const char* fileName = tinyfd_openFileDialog("Select file to deserialize", nullptr, 0, nullptr, nullptr, 0);
+    if (fileName == nullptr)
     {
         LOG_INFO("No file selected. Stopping debugging...");
         debugStop = true;

--- a/src/app/windows/consoleWindow.cpp
+++ b/src/app/windows/consoleWindow.cpp
@@ -791,12 +791,13 @@ void consoleWindow() {
         commandTextHeight + style.FramePadding.y * 2.0f,
         ImGui::GetFrameHeight(),
         ImGui::GetTextLineHeightWithSpacing() * 4.0f + style.FramePadding.y * 2.0f);
-    const float footerHeightToReserve = style.ItemSpacing.y + commandInputHeight;
+    const float separatorHeight = style.ItemSpacing.y + 1.0f;
+    const float footerHeightToReserve = separatorHeight + commandInputHeight;
 
-    // --- Output region (selectable, copyable) ---
+    // --- Output region ---
 
     ImGui::BeginChild("ScrollingRegion", ImVec2(0, -footerHeightToReserve),
-                      ImGuiChildFlags_None, ImGuiWindowFlags_None);
+                      ImGuiChildFlags_FrameStyle, ImGuiWindowFlags_None);
 
     if (firstRender) {
         registerCommands();
@@ -825,20 +826,16 @@ void consoleWindow() {
         bufferDirty = false;
     }
 
-    const float availWidth = ImGui::GetContentRegionAvail().x;
-    const float outputWrapWidth = std::max(1.0f, availWidth - style.FramePadding.x * 2.0f - style.ScrollbarSize);
-    const float outputTextHeight = ImGui::GetFont()->CalcTextSizeA(
-        ImGui::GetFontSize(), outputWrapWidth, outputWrapWidth, displayBuffer, nullptr).y;
-    const float textHeight = std::max(ImGui::GetTextLineHeight(), outputTextHeight) +
-                             style.FramePadding.y * 2.0f;
+    ImGui::PushTextWrapPos(ImGui::GetCursorPos().x + ImGui::GetContentRegionAvail().x);
+    ImGui::TextUnformatted(displayBuffer);
+    ImGui::PopTextWrapPos();
 
-    ImGui::PushStyleColor(ImGuiCol_FrameBg, ImColor(24, 25, 38, 255).Value);
-    ImGui::InputTextMultiline("##ConsoleOutput", displayBuffer, sizeof(displayBuffer),
-                              ImVec2(availWidth, textHeight),
-                              ImGuiInputTextFlags_ReadOnly |
-                                  ImGuiInputTextFlags_NoHorizontalScroll |
-                                  ImGuiInputTextFlags_WordWrap);
-    ImGui::PopStyleColor();
+    if (ImGui::BeginPopupContextWindow("ConsoleOutputContextMenu", ImGuiPopupFlags_MouseButtonRight)) {
+        if (ImGui::MenuItem("Copy Output")) {
+            ImGui::SetClipboardText(displayBuffer);
+        }
+        ImGui::EndPopup();
+    }
 
     // Auto-scroll logic
     if (autoScroll) {
@@ -856,9 +853,6 @@ void consoleWindow() {
     ImGui::Separator();
 
     // --- Command input region ---
-    ImGui::BeginChild("FixedInputRegion", ImVec2(0, footerHeightToReserve),
-                      ImGuiChildFlags_None, ImGuiWindowFlags_NoScrollbar);
-
     ImGui::PushItemWidth(-1);
     if (ImGui::InputTextMultiline("##Command", input, IM_ARRAYSIZE(input),
                                   ImVec2(0, commandInputHeight),
@@ -893,7 +887,6 @@ void consoleWindow() {
     }
 
     ImGui::PopItemWidth();
-    ImGui::EndChild();
     ImGui::PopFont();
     ImGui::End();
 }

--- a/src/app/windows/memoryMapView.cpp
+++ b/src/app/windows/memoryMapView.cpp
@@ -1,65 +1,5 @@
 #include "windows.hpp"
 
-std::vector<MemRegionInfo> getMemoryMapping(Icicle* ic)
-{
-    if (remote_gdb::useRemoteDebugging()) {
-        std::vector<MemRegionInfo> memMapInfo;
-        for (const auto& region : remote_gdb::remoteMemoryRegions()) {
-            MemoryProtection protection = NoAccess;
-            if (region.read && region.write && region.execute) {
-                protection = ExecuteReadWrite;
-            } else if (region.read && region.write) {
-                protection = ReadWrite;
-            } else if (region.read && region.execute) {
-                protection = ExecuteRead;
-            } else if (region.execute) {
-                protection = ExecuteOnly;
-            } else if (region.read) {
-                protection = ReadOnly;
-            }
-
-            memMapInfo.push_back({region.start, region.end - region.start, protection});
-        }
-        return memMapInfo;
-    }
-
-    if (!ic) {
-        return {};
-    }
-
-    size_t count = 0;
-    MemRegionInfo* memRegionInfoArray = icicle_mem_list_mapped(ic, &count);
-    
-    std::vector<MemRegionInfo> memMapInfo;
-    memMapInfo.reserve(count);
-
-    if (memRegionInfoArray) {
-        for (size_t i = 0; i < count; i++) {
-            memMapInfo.push_back(memRegionInfoArray[i]);
-        }
-
-        icicle_mem_list_mapped_free(memRegionInfoArray, count);
-    }
-
-    return memMapInfo;
-}
-
-inline bool updateMemoryPermissions(Icicle* ic, const uint64_t startAddr, const uint64_t endAddr,
-                                    const MemoryProtection newPerms)
-{
-    if (!ic) {
-        return false;
-    }
-
-    auto err = icicle_mem_protect(ic, startAddr, endAddr - startAddr, newPerms);
-    if (err != 0)
-    {
-        return false;
-    }
-
-    return true;
-}
-
 bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAddr, uint64_t newEndAddr,
                         const uint64_t oldSize, const MemoryProtection perms)
 {
@@ -158,7 +98,7 @@ void memoryMapWindow()
         return;
     }
 
-    auto memInfo = getMemoryMapping(icicle);
+    auto memInfo = debugMemoryRegions();
     auto [x, y] = ImGui::GetWindowSize();
     ImGui::SetNextWindowSize({x - 230, (y - 125 + (52 * memInfo.size()))});
 
@@ -371,7 +311,7 @@ void memoryMapWindow()
 
                     if (unmap)
                     {
-                        icicle_mem_unmap(icicle, memInfo[i].address, memInfo[i].size);
+                        unmapDebugMemory(memInfo[i].address, memInfo[i].size);
                     }
                 }
 
@@ -399,7 +339,7 @@ void memoryMapWindow()
                         newPerms = NoAccess;
                     }
                     
-                    updateMemoryPermissions(icicle, memInfo[i].address, memInfo[i].address + memInfo[i].size, newPerms);
+                    protectDebugMemory(memInfo[i].address, memInfo[i].size, newPerms);
                     permsChanged = false;
                 }
 
@@ -459,8 +399,7 @@ void memoryMapWindow()
         auto [address, size] = infoPopup("Map a new region", "Multiple of 4KB");
         if (address != 0 && size != 0)
         {
-            auto err = icicle_mem_map(icicle, address, size, MemoryProtection::NoAccess);
-            if (err != 0)
+            if (!mapDebugMemory(address, size, MemoryProtection::NoAccess))
             {
                 LOG_INFO("Unable to map the newly requested memory region.");
                 keep = false;

--- a/src/app/windows/memoryMapView.cpp
+++ b/src/app/windows/memoryMapView.cpp
@@ -98,6 +98,7 @@ void memoryMapWindow()
         return;
     }
 
+    const bool allowMemoryMapEdits = !remote_gdb::useRemoteDebugging();
     auto memInfo = debugMemoryRegions();
     auto [x, y] = ImGui::GetWindowSize();
     ImGui::SetNextWindowSize({x - 230, (y - 125 + (52 * memInfo.size()))});
@@ -107,6 +108,9 @@ void memoryMapWindow()
         bool tableSizeInc = false;
         bool tableUpdated = false;
         bool mapped = true;
+        if (!allowMemoryMapEdits) {
+            ImGui::TextWrapped("Remote memory maps are read-only in this view.");
+        }
         ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[JetBrainsMono20]);
         if (ImGui::BeginTable("memoryMapTable", 4,
                               ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_Resizable))
@@ -232,6 +236,9 @@ void memoryMapWindow()
                 uint64_t endAddr = memInfo[i].size + memInfo[i].address;
                 const std::string endAddrText = std::to_string(endAddr);
                 std::snprintf(inputValue, 80, "%s", endAddrText.c_str());
+                if (!allowMemoryMapEdits) {
+                    ImGui::BeginDisabled();
+                }
                 if (InputHexadecimal("##end_addr", inputValue, ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     newEndAddr = strtoll(inputValue, nullptr, 16);
@@ -239,6 +246,9 @@ void memoryMapWindow()
                     {
                         endAddrChanged = true;
                     }
+                }
+                if (!allowMemoryMapEdits) {
+                    ImGui::EndDisabled();
                 }
 
                 ImGui::PopID();
@@ -248,6 +258,9 @@ void memoryMapWindow()
 
                 posX = ImGui::GetCursorPosX() + 2;
 
+                if (!allowMemoryMapEdits) {
+                    ImGui::BeginDisabled();
+                }
                 ImGui::SetCursorPosX(posX);
                 ImGui::Selectable("Read: ");
                 ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[6]);
@@ -314,6 +327,9 @@ void memoryMapWindow()
                         unmapDebugMemory(memInfo[i].address, memInfo[i].size);
                     }
                 }
+                if (!allowMemoryMapEdits) {
+                    ImGui::EndDisabled();
+                }
 
                 ImGui::PopFont ();
                 ImGui::TableNextRow();
@@ -321,7 +337,7 @@ void memoryMapWindow()
                 ImGui::PopStyleColor();
                 ImGui::PopID();
 
-                if (permsChanged)
+                if (allowMemoryMapEdits && permsChanged)
                 {
                     // Convert individual flags back to MemoryProtection enum
                     MemoryProtection newPerms;
@@ -343,7 +359,7 @@ void memoryMapWindow()
                     permsChanged = false;
                 }
 
-                if (endAddrChanged)
+                if (allowMemoryMapEdits && endAddrChanged)
                 {
                     if (expandMemoryRegion(icicle, memInfo[i].address, memInfo[i].size + memInfo[i].address,
                                            newEndAddr,
@@ -371,9 +387,15 @@ void memoryMapWindow()
         }
 
         ImGui::PushFont(ImGui::GetIO().Fonts->Fonts[RubikRegular16]);
+        if (!allowMemoryMapEdits) {
+            ImGui::BeginDisabled();
+        }
         if (ImGui::Button("ADD"))
         {
             keep = true;
+        }
+        if (!allowMemoryMapEdits) {
+            ImGui::EndDisabled();
         }
 
 
@@ -394,7 +416,7 @@ void memoryMapWindow()
         ImGui::PopFont();
     }
 
-    if (keep)
+    if (keep && allowMemoryMapEdits)
     {
         auto [address, size] = infoPopup("Map a new region", "Multiple of 4KB");
         if (address != 0 && size != 0)

--- a/src/app/windows/memoryMapView.cpp
+++ b/src/app/windows/memoryMapView.cpp
@@ -23,24 +23,35 @@ std::vector<MemRegionInfo> getMemoryMapping(Icicle* ic)
         return memMapInfo;
     }
 
-    size_t count;
-    MemRegionInfo* memRegionInfoArray = icicle_mem_list_mapped(icicle, &count);
+    if (!ic) {
+        return {};
+    }
+
+    size_t count = 0;
+    MemRegionInfo* memRegionInfoArray = icicle_mem_list_mapped(ic, &count);
     
     std::vector<MemRegionInfo> memMapInfo;
     memMapInfo.reserve(count);
 
-    for (size_t i = 0; i < count; i++) {
-        memMapInfo.push_back(memRegionInfoArray[i]);
+    if (memRegionInfoArray) {
+        for (size_t i = 0; i < count; i++) {
+            memMapInfo.push_back(memRegionInfoArray[i]);
+        }
+
+        icicle_mem_list_mapped_free(memRegionInfoArray, count);
     }
 
-    icicle_mem_list_mapped_free(memRegionInfoArray, count);
     return memMapInfo;
 }
 
 inline bool updateMemoryPermissions(Icicle* ic, const uint64_t startAddr, const uint64_t endAddr,
                                     const MemoryProtection newPerms)
 {
-    auto err = icicle_mem_protect(icicle, startAddr, endAddr - startAddr, newPerms);
+    if (!ic) {
+        return false;
+    }
+
+    auto err = icicle_mem_protect(ic, startAddr, endAddr - startAddr, newPerms);
     if (err != 0)
     {
         return false;
@@ -52,6 +63,11 @@ inline bool updateMemoryPermissions(Icicle* ic, const uint64_t startAddr, const 
 bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAddr, uint64_t newEndAddr,
                         const uint64_t oldSize, const MemoryProtection perms)
 {
+    if (!ic)
+    {
+        return false;
+    }
+
     if (!(perms & MemoryProtection::ReadWrite) && !(perms & MemoryProtection::ExecuteReadWrite))
     {
         LOG_ERROR("The memory region expansion process could not be completed because the memory region does not have read and write permissions.");
@@ -79,6 +95,11 @@ bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAdd
     }
 
     VmSnapshot* tempMemSnapshot = icicle_vm_snapshot(ic);
+    if (!tempMemSnapshot)
+    {
+        LOG_ERROR("Unable to snapshot memory before expansion.");
+        return false;
+    }
     // maybe allocate a page?
     // const auto saved = static_cast<char*>(malloc(oldSize));
     // size_t outSize{};
@@ -90,7 +111,7 @@ bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAdd
     //     return false;
     // }
 
-    int err = icicle_mem_unmap(icicle, startAddr, oldSize);
+    int err = icicle_mem_unmap(ic, startAddr, oldSize);
     if (err != 0)
     {
         LOG_ERROR("Unable to unmap the memory region for expansion.");
@@ -98,7 +119,7 @@ bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAdd
         return false;
     }
 
-    err = icicle_mem_map(icicle, startAddr, newSize, perms);
+    err = icicle_mem_map(ic, startAddr, newSize, perms);
     if (err != 0){
         LOG_ERROR("Unable to remap the memory region which was unmapped with a bigger size!");
         LOG_NOTICE("Attempting to recover the unmapped memory region...");
@@ -110,14 +131,18 @@ bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAdd
 
         LOG_INFO("The memory maps are now in the default state.");
         icicle_vm_snapshot_free(tempMemSnapshot);
-        return true;
+        return false;
     }
 
     // we have to touch the avoid fragmentation bug
     size_t outSize{};
-    icicle_mem_read(icicle, startAddr, newSize, &outSize);
+    auto* touchedMemory = icicle_mem_read(ic, startAddr, newSize, &outSize);
+    if (touchedMemory)
+    {
+        icicle_free_buffer(touchedMemory, outSize);
+    }
 
-    std::cout << "After the remapping" << std::endl;
+    icicle_vm_snapshot_free(tempMemSnapshot);
     return true;
 }
 
@@ -265,7 +290,8 @@ void memoryMapWindow()
                 ImGui::PushID(("third" + std::to_string(i)).c_str());
                 ImGui::SetNextItemWidth(150);
                 uint64_t endAddr = memInfo[i].size + memInfo[i].address;
-                strncpy(inputValue, std::to_string(endAddr).c_str(), std::to_string(endAddr).length());
+                const std::string endAddrText = std::to_string(endAddr);
+                std::snprintf(inputValue, 80, "%s", endAddrText.c_str());
                 if (InputHexadecimal("##end_addr", inputValue, ImGuiInputTextFlags_CharsNoBlank | ImGuiInputTextFlags_EnterReturnsTrue))
                 {
                     newEndAddr = strtoll(inputValue, nullptr, 16);

--- a/src/app/windows/stackWindow.cpp
+++ b/src/app/windows/stackWindow.cpp
@@ -68,8 +68,6 @@ bool handleStackError() {
 }
 
 static std::unique_ptr<unsigned char[], decltype(&free)> stackBuffer(nullptr, free);
-unsigned char* stackEditorData;
-unsigned char* stackEditorTemp;
 
 void stackEditorWindow() {
     const auto io = ImGui::GetIO();

--- a/src/app/windows/stackWindow.cpp
+++ b/src/app/windows/stackWindow.cpp
@@ -49,7 +49,7 @@ bool handleStackError() {
 
     if (1) {
         const auto result = icicle_mem_map(icicle, STACK_ADDRESS, STACK_SIZE, MemoryProtection::ReadWrite);
-        if (result != 0) {
+        if (result == 0) {
             LOG_INFO("Successfully mapped stack memory at 0x" << std::hex << STACK_ADDRESS);
             showPopupError = false;
             return true;
@@ -93,7 +93,7 @@ void stackEditorWindow() {
                 LOG_INFO("Stack memory is already mapped");
             } else {
                 LOG_INFO("Stack memory needs mapping");
-                if (icicle_mem_map(icicle, STACK_ADDRESS, STACK_SIZE, ReadWrite) != 0) {
+                if (icicle_mem_map(icicle, STACK_ADDRESS, STACK_SIZE, ReadWrite) == 0) {
                     LOG_INFO("Successfully mapped stack memory");
                 } else {
                     LOG_ERROR("Failed to map stack memory!");

--- a/src/app/windows/windows.hpp
+++ b/src/app/windows/windows.hpp
@@ -26,13 +26,6 @@ enum contextMenuOption {
     NORMAL_ACTION
 };
 
-typedef struct
-{
-    uint64_t start;
-    uint64_t end;
-    MemoryProtection perms;
-} memoryMapInfo;
-
 enum arch{
     x86 = 0,
     ARM,
@@ -65,7 +58,6 @@ extern bool debugRun;
 extern bool enableDebugMode;
 extern bool memoryMapsUI;
 
-extern const uc_mode x86UCModes[];
 extern const char* x86ModeStr[];
 extern const char* armModeStr[];
 extern const cs_arch csArchs[];
@@ -106,9 +98,6 @@ extern bool updateRegistersOnLaneChange();
 extern void memoryMapWindow();
 extern std::pair<size_t, size_t> infoPopup(const std::string& title = "", const std::string& sizeHint = "");
 extern std::vector<newMemEditWindowsInfo> newMemEditWindows;
-extern unsigned char* stackEditorData;
-extern unsigned char* stackEditorTemp;
-extern void cleanupStackEditor();
 extern std::string consoleOutput;
 extern std::mutex  consoleOutputMutex;
 extern void consoleWriteThreadSafe(const std::string& text);

--- a/src/app/windows/windows.hpp
+++ b/src/app/windows/windows.hpp
@@ -103,7 +103,6 @@ extern void parseRegisterValueInput(const std::string& regName, const char *regV
 extern void removeRegisterFromView(const std::string& reg, int regType = 1);
 extern std::string getRegisterActualName(const std::string& regName);
 extern bool updateRegistersOnLaneChange();
-extern std::vector<memoryMapInfo> getMemoryMapping(uc_engine* uc);
 extern void memoryMapWindow();
 extern std::pair<size_t, size_t> infoPopup(const std::string& title = "", const std::string& sizeHint = "");
 extern std::vector<newMemEditWindowsInfo> newMemEditWindows;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -216,8 +216,6 @@ int main(int argc, const char** argv)
     stackEditor.WriteFn = &stackWriteFunc;
     stackEditor.OptShowAscii = false;
     stackEditor.Cols = 8;
-    stackEditorData = nullptr;
-    stackEditorTemp = nullptr;
     stackArraysZeroed = false;
 
     glfwShowWindow(window);
@@ -277,18 +275,6 @@ int main(int argc, const char** argv)
         runActions();
     }
 
-    // Cleanup memory
-
-    // Free legacy pointers if somehow allocated
-    if (stackEditorData) {
-        free(stackEditorData);
-        stackEditorData = nullptr;
-    }
-    if (stackEditorTemp) {
-        free(stackEditorTemp);
-        stackEditorTemp = nullptr;
-    }
-    
     if (icicle != nullptr)
     {
         icicle_free(icicle);

--- a/src/tests/elfSymbolsTest.cpp
+++ b/src/tests/elfSymbolsTest.cpp
@@ -1,0 +1,61 @@
+#include "integration/gdb/elfSymbols.hpp"
+
+#include <elf.h>
+
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <vector>
+
+namespace {
+
+std::filesystem::path writeFixture(const std::string& name, const std::vector<uint8_t>& bytes)
+{
+    const auto path = std::filesystem::temp_directory_path() / name;
+    std::ofstream out(path, std::ios::binary | std::ios::trunc);
+    out.write(reinterpret_cast<const char*>(bytes.data()), static_cast<std::streamsize>(bytes.size()));
+    return path;
+}
+
+bool expectNoSymbols(const std::string& name, const std::vector<uint8_t>& bytes)
+{
+    const auto path = writeFixture(name, bytes);
+    const auto symbols = remote_gdb::loadElfSymbols(path.string());
+    std::filesystem::remove(path);
+
+    if (!symbols.addrToName.empty())
+    {
+        std::cerr << "Expected no symbols for " << name << '\n';
+        return false;
+    }
+
+    return true;
+}
+
+std::vector<uint8_t> malformedElf64WithOutOfRangeSections()
+{
+    std::vector<uint8_t> bytes(sizeof(Elf64_Ehdr), 0);
+    auto* header = reinterpret_cast<Elf64_Ehdr*>(bytes.data());
+    header->e_ident[EI_MAG0] = ELFMAG0;
+    header->e_ident[EI_MAG1] = ELFMAG1;
+    header->e_ident[EI_MAG2] = ELFMAG2;
+    header->e_ident[EI_MAG3] = ELFMAG3;
+    header->e_ident[EI_CLASS] = ELFCLASS64;
+    header->e_shoff = 0x1000;
+    header->e_shentsize = sizeof(Elf64_Shdr);
+    header->e_shnum = 1;
+    header->e_shstrndx = 0;
+    return bytes;
+}
+
+}
+
+int main()
+{
+    bool ok = true;
+    ok &= expectNoSymbols("zathura-empty-elf-fixture", {});
+    ok &= expectNoSymbols("zathura-short-elf-fixture", {ELFMAG0, ELFMAG1, ELFMAG2});
+    ok &= expectNoSymbols("zathura-malformed-elf64-fixture", malformedElf64WithOutOfRangeSections());
+    return ok ? 0 : 1;
+}

--- a/src/tests/elfSymbolsTest.cpp
+++ b/src/tests/elfSymbolsTest.cpp
@@ -49,6 +49,22 @@ std::vector<uint8_t> malformedElf64WithOutOfRangeSections()
     return bytes;
 }
 
+std::vector<uint8_t> malformedElf64WithUnexpectedSectionEntrySize()
+{
+    std::vector<uint8_t> bytes(sizeof(Elf64_Ehdr) + sizeof(Elf64_Shdr) + 8, 0);
+    auto* header = reinterpret_cast<Elf64_Ehdr*>(bytes.data());
+    header->e_ident[EI_MAG0] = ELFMAG0;
+    header->e_ident[EI_MAG1] = ELFMAG1;
+    header->e_ident[EI_MAG2] = ELFMAG2;
+    header->e_ident[EI_MAG3] = ELFMAG3;
+    header->e_ident[EI_CLASS] = ELFCLASS64;
+    header->e_shoff = sizeof(Elf64_Ehdr);
+    header->e_shentsize = sizeof(Elf64_Shdr) + 8;
+    header->e_shnum = 1;
+    header->e_shstrndx = 0;
+    return bytes;
+}
+
 }
 
 int main()
@@ -57,5 +73,7 @@ int main()
     ok &= expectNoSymbols("zathura-empty-elf-fixture", {});
     ok &= expectNoSymbols("zathura-short-elf-fixture", {ELFMAG0, ELFMAG1, ELFMAG2});
     ok &= expectNoSymbols("zathura-malformed-elf64-fixture", malformedElf64WithOutOfRangeSections());
+    ok &= expectNoSymbols("zathura-oversized-shentsize-elf64-fixture",
+                          malformedElf64WithUnexpectedSectionEntrySize());
     return ok ? 0 : 1;
 }

--- a/vendor/icicle-cpp/CMakeLists.txt
+++ b/vendor/icicle-cpp/CMakeLists.txt
@@ -1,0 +1,46 @@
+cmake_minimum_required(VERSION 3.15)
+project(icicle-cpp LANGUAGES C)
+
+set(CARGO_MANIFEST_PATH "${CMAKE_CURRENT_SOURCE_DIR}/src/Cargo.toml")
+
+# Resolve the target directory the same way cargo does.
+if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    set(CARGO_BUILD_FLAGS "")
+    set(CARGO_TARGET_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/target/debug")
+else()
+    set(CARGO_BUILD_FLAGS "--release")
+    set(CARGO_TARGET_DIR "${CMAKE_CURRENT_SOURCE_DIR}/src/target/release")
+endif()
+
+# Optional: set a cargo target triple for cross-compilation.
+if(DEFINED CARGO_TARGET_TRIPLE)
+    set(CARGO_TARGET_FLAGS "--target=${CARGO_TARGET_TRIPLE}")
+    set(CARGO_TARGET_DIR "${CARGO_TARGET_DIR}/${CARGO_TARGET_TRIPLE}")
+endif()
+
+set(ICICLE_LIB "${CARGO_TARGET_DIR}/${CMAKE_STATIC_LIBRARY_PREFIX}icicle${CMAKE_STATIC_LIBRARY_SUFFIX}")
+
+add_custom_command(
+    OUTPUT  "${ICICLE_LIB}"
+    COMMAND cargo build ${CARGO_BUILD_FLAGS} ${CARGO_TARGET_FLAGS} --manifest-path "${CARGO_MANIFEST_PATH}"
+    WORKING_DIRECTORY "${CMAKE_CURRENT_SOURCE_DIR}"
+    COMMENT "Building icicle (Rust -> static library)"
+    VERBATIM
+)
+
+add_custom_target(icicle_build DEPENDS "${ICICLE_LIB}")
+
+add_library(icicle STATIC IMPORTED GLOBAL)
+set_target_properties(icicle PROPERTIES
+    IMPORTED_LOCATION             "${ICICLE_LIB}"
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}"
+)
+add_dependencies(icicle icicle_build)
+
+# Platform-specific link dependencies.
+if(WIN32)
+    set(ICICLE_PLATFORM_LIBS ws2_32.lib Userenv.lib ntdll.lib Bcrypt.lib)
+    set_target_properties(icicle PROPERTIES
+        INTERFACE_LINK_LIBRARIES "${ICICLE_PLATFORM_LIBS}"
+    )
+endif()

--- a/vendor/icicle-cpp/README.md
+++ b/vendor/icicle-cpp/README.md
@@ -1,74 +1,85 @@
 # Icicle
+
 [Icicle](https://github.com/icicle-emu/icicle-emu) is an experimental fuzzing-specific, multi-architecture emulation framework.
 
 ## C/C++ Bindings
-This project aims to provide C/C++ bindings for the icicle emulator. I'd also like to write full on documentation on this soon.
 
-## Usage
-Using these bindings is as simple as compiling the static library using cargo and then including it in your project using your compiler or make, cmake, etc.
-If you just want the library and the header file, you can download it from the [releases page](https://github.com/HACKE-RC/icicle-cpp/tags)
+This project provides C/C++ FFI bindings to the icicle emulator as a static Rust library with a single-header C API (`icicle.h`).
 
-### Compilation
-Getting the static library is as simple as
+## Building
+
 ```sh
-git clone https://github.com/HACKE-RC/icicle-cpp
-cd icicle-cpp
-cd src
-cargo build     # you can use cargo build --release if you want the release build
+git clone --recurse-submodules https://github.com/HACKE-RC/icicle-cpp
+cd icicle-cpp/src
+cargo build --release
 ```
 
-The static library will now be built in `icicle-cpp/src/target/<build_type>/libicicle.a`. Here, <build_type> will be `debug` if you do not use the `--release` flag with cargo
-and `release` if you do.
+The static library will be at `src/target/release/libicicle.a`. For a full build-and-test cycle:
 
-# Comprehensive Icicle Hook Testing
-
-This project provides a robust test for the Icicle emulator's hook functionality. The test demonstrates all three types of hooks:
-1. Execution hooks - triggered when a block of code executes
-2. Syscall hooks - triggered when the program makes a system call
-3. Violation hooks - triggered when a memory access violation occurs
-
-## Test Program Details
-
-The test program:
-
-1. Creates an x86_64 virtual machine
-2. Maps various memory regions with different permissions
-3. Loads a comprehensive test program that:
-   - Executes various x86_64 instructions
-   - Performs memory reads/writes
-   - Attempts to write to read-only memory (triggers violation hook)
-   - Makes a syscall (triggers syscall hook)
-4. Registers all three types of hooks with detailed callbacks
-5. Runs the emulation with hooks enabled
-6. Tests hook removal by removing the syscall hook and verifying it no longer triggers
-
-## Expected Output
-
-The test program provides detailed output about:
-- Hook registration
-- Hook triggering with full context (addresses, permissions, etc.)
-- Statistics on how many times each hook was triggered
-- Verification that hook removal works
-
-## Building and Running
-
-To build and run the test:
-
-```bash
-# Compile the test program
-make -f hook_test_Makefile
-
-# Run the test
-./hook_test
+```sh
+./build_and_test.sh
 ```
 
-## Hook Implementations
+## Implementation
 
-The Rust implementation includes:
+The wrapper is a Rust `staticlib` crate exposing `#[no_mangle] pub extern "C"` functions for every operation in `icicle.h`.
 
-1. `icicle_add_violation_hook`: Adds a memory violation hook
-2. `icicle_add_syscall_hook`: Adds a syscall interception hook
-3. `icicle_add_execution_hook`: Adds a basic block execution hook
-4. `icicle_remove_hook`: Removes a previously registered hook
+**Module layout** (`src/`):
 
-Each hook has detailed callback functions that report what's happening during emulation.
+| File | Purpose |
+|------|---------|
+| `types.rs` | FFI callback type aliases, `#[repr(C)]` structs (`SyscallArgs`, `CpuSnapshot`, `MemRegionInfo`), enums (`MemoryProtection`, `RunStatus`, `CoverageMode`), and permission mapping helpers |
+| `vm.rs` | `Icicle` struct (wrapping `icicle_vm::Vm`), all core VM methods (`new`, `run`, `mem_map`, `reg_read`, etc.), `reg_find`, and `vm_exit_to_run_status` |
+| `lib.rs` | ~60 `#[no_mangle]` FFI entry points — hooks, snapshots, coverage instrumentation, debug instrumentation, serialization, breakpoints, and memory region listing |
+
+**Key design decisions**:
+
+- **Hook lifecycle**: Violation (ID 1) and syscall (ID 2) hooks are singletons stored in `Option` fields on the `Icicle` struct. Execution hooks and memory hooks use `HashMap<u32, Box<dyn ...>>` tracking maps with a monotonically incrementing ID counter (starting at 1 or 3 respectively, leaving 0 as the failure sentinel). Hook removal from the core VM is a known limitation — the upstream API does not expose `remove_hook`, so dropping the tracked closure makes the hook a no-op but does not de-register it from the VM.
+
+- **Exception handling in `run()`**: The `run()` method loops on `VmExit::UnhandledException`, dispatching to the violation or syscall callback if registered. The violation path handles the common x86-64 "write to NULL" pattern by advancing PC past the faulting instruction. The syscall path reads x86-64 calling-convention registers (RAX, RDI, RSI, RDX, R10, R8, R9) and advances PC by 2 bytes (the length of `syscall` on x86-64). Non-x86 architectures are guarded and propagate the exception unhandled.
+
+- **Serialization**: `SerializableVmState` captures register state as a raw byte image of the `Regs` struct (via `bincode`), plus shadow stack entries, exception state, icount, and optionally all mapped memory regions. `zstd` compression is supported. The CPU-only path skips the memory scan entirely.
+
+- **Coverage**: Four modes (Blocks, Edges, BlockCounts, EdgeCounts) are implemented as `FnMut` closures holding a raw `*mut Vec<u8>` into `Icicle.coverage_map`. Mode switches resize the map in-place to avoid invalidating the pointer held by still-registered hooks.
+
+- **Snapshot/restore**: `CpuSnapshot` and `VmSnapshot` are `#[repr(C)]` structs with opaque heap-allocated fields. Save allocates, restore copies back into the live CPU/VM, and free drops each allocation.
+
+## CMake integration
+
+Add icicle-cpp as a subdirectory or `ExternalProject` and link against it:
+
+```cmake
+# Option A: add_subdirectory — a CMakeLists.txt is provided in the repo root
+add_subdirectory(vendor/icicle-cpp)
+target_link_libraries(your_target PRIVATE icicle)
+
+# Option B: ExternalProject (cross-platform, cross-compile friendly)
+include(ExternalProject)
+
+set(ICICLE_PREFIX "${CMAKE_CURRENT_BINARY_DIR}/icicle-cpp")
+
+ExternalProject_Add(icicle-cpp
+    GIT_REPOSITORY  https://github.com/HACKE-RC/icicle-cpp
+    GIT_TAG         master
+    PREFIX          "${ICICLE_PREFIX}"
+    CONFIGURE_COMMAND ""
+    BUILD_COMMAND   cargo build --release --manifest-path src/Cargo.toml
+    BUILD_IN_SOURCE 1
+    INSTALL_COMMAND ""
+    BUILD_BYPRODUCTS "${ICICLE_PREFIX}/src/icicle-cpp/src/target/release/${CMAKE_STATIC_LIBRARY_PREFIX}icicle${CMAKE_STATIC_LIBRARY_SUFFIX}"
+)
+
+add_library(icicle STATIC IMPORTED)
+set_target_properties(icicle PROPERTIES
+    IMPORTED_LOCATION "${ICICLE_PREFIX}/src/icicle-cpp/src/target/release/${CMAKE_STATIC_LIBRARY_PREFIX}icicle${CMAKE_STATIC_LIBRARY_SUFFIX}"
+    INTERFACE_INCLUDE_DIRECTORIES "${ICICLE_PREFIX}/src/icicle-cpp"
+)
+add_dependencies(icicle icicle-cpp)
+
+target_link_libraries(your_target PRIVATE icicle)
+```
+
+On Windows (MSVC), also link system libraries:
+```cmake
+target_link_libraries(your_target PRIVATE ws2_32.lib Userenv.lib ntdll.lib Bcrypt.lib)
+```


### PR DESCRIPTION
## Summary
- Fix debugger execution state handling, snapshot cleanup, stack mapping checks, and register lookup safety.
- Harden remote GDB packet handling and ELF symbol parsing, with a regression test for malformed ELF inputs.
- Clean up memory-map UI behavior, console layout, and icicle-cpp CMake/docs integration.

## Test plan
- `cmake --build build`
- `ctest --test-dir build --output-on-failure`


Made with [Cursor](https://cursor.com)