### PR TITLE
Standard debugger keybindings + browser key capture

### DIFF
--- a/src/app/buttons.cpp
+++ b/src/app/buttons.cpp
@@ -88,7 +88,7 @@ bool setupButtons() {
 
          if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Run (F10)");
+            ImGui::Text("Run (Ctrl+F5)");
             ImGui::EndTooltip();
         }
 
@@ -114,7 +114,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Restart Debugging (CTRL+F5)");
+            ImGui::Text("Restart Debugging (Ctrl+Shift+F5)");
             ImGui::EndTooltip();
         }
 
@@ -142,7 +142,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Step Over (CTRL+K)");
+            ImGui::Text("Step Over (F10)");
             ImGui::EndTooltip();
         }
 
@@ -156,7 +156,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Step In (CTRL+J)");
+            ImGui::Text("Step In (F11)");
             ImGui::EndTooltip();
         }
 
@@ -219,7 +219,7 @@ bool setupButtons() {
     }
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
-        ImGui::Text("Restart Debugging (CTRL+F5)");
+        ImGui::Text("Restart Debugging (Ctrl+Shift+F5)");
         ImGui::EndTooltip();
     }
     const char* targetLabel = remote_gdb::useRemoteDebugging() ? "Server" : "Emulation";

--- a/src/app/menuBar.cpp
+++ b/src/app/menuBar.cpp
@@ -337,10 +337,10 @@ void appMenuBar()
                 ImGui::MenuItem("Stop debugging", "Shift+F5", &debugStop);
             }
             ImGui::MenuItem("Configure target", nullptr, &showDebugTargetSettings);
-            ImGui::MenuItem("Step In", "CTRL+J", &debugStepIn, debugModeEnabled ? true : false);
-            ImGui::MenuItem("Step Over", "CTRL+K", &debugStepOver, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Step Over", "F10", &debugStepOver, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Step In", "F11", &debugStepIn, debugModeEnabled ? true : false);
             ImGui::MenuItem("Continue", debugModeEnabled ? "F5" : nullptr, &debugContinue, debugModeEnabled ? true : false);
-            ImGui::MenuItem("Restart debugging", "CTRL+F5", &debugRestart, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Restart debugging", "Ctrl+Shift+F5", &debugRestart, debugModeEnabled ? true : false);
             ImGui::MenuItem("Memory maps", "CTRL+F7", &memoryMapsUI, debugModeEnabled ? true : false);
             ImGui::MenuItem("Breakpoints", nullptr, &breakpointsUI, true);
             ImGui::MenuItem("Watchpoints", nullptr, &watchpointsUI, true);

--- a/src/app/shortcuts.cpp
+++ b/src/app/shortcuts.cpp
@@ -47,48 +47,69 @@ void manageShortcuts(){
         use32BitLanes = !use32BitLanes;
         updateRegistersOnLaneChange();
     }
-    if (isShiftOnly && (ImGui::IsKeyPressed(ImGuiKey_F5))){
+    const auto noMod = !alt && !ctrl && !shift && !super;
+
+    // --- Debugger controls: standard IDE keys (VS Code / Visual Studio) ------
+    // These avoid the Ctrl+J/Ctrl+K bindings that browsers steal (Downloads,
+    // search bar) and match what developers expect everywhere.
+    //
+    //   F5            Start debugging / Continue
+    //   Shift+F5      Stop
+    //   Ctrl+F5       Run without debugging
+    //   Ctrl+Shift+F5 Restart
+    //   F10           Step over
+    //   F11           Step into
+    //   Shift+F11     Step back (time-travel)
+    //   F9            Toggle breakpoint
+    //   F6            Pause
+    if (isShiftOnly && IsKeyPressed(ImGuiKey_F5)){
         if (debugModeEnabled){
             debugStop = true;
         }
         return;
     }
-    else if (ImGui::IsKeyPressed(ImGuiKey_F5)){
+    if (isCtrlShiftShortcut && IsKeyPressed(ImGuiKey_F5)){
+        if (debugModeEnabled){
+            debugRestart = true;
+        }
+        return;
+    }
+    if (isCtrlShortcut && IsKeyPressed(ImGuiKey_F5)){
+        debugRun = true;
+        return;
+    }
+    if (noMod && IsKeyPressed(ImGuiKey_F5)){
         if (!debugModeEnabled){
             enableDebugMode = true;
-        }
-        else if ((isCtrlShortcut) &&ImGui::IsKeyPressed(ImGuiKey_F5)){
-            debugRestart = true;
         }
         else{
             debugContinue = true;
         }
     }
+
     if (debugModeEnabled){
-        if (isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_J))){
-            debugStepIn = true;
-        }
-        if (isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_K))){
+        if (noMod && IsKeyPressed(ImGuiKey_F10)){
             debugStepOver = true;
         }
-        if (ttdEnabled && isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_B))){
+        if (noMod && IsKeyPressed(ImGuiKey_F11)){
+            debugStepIn = true;
+        }
+        if (ttdEnabled && isShiftOnly && IsKeyPressed(ImGuiKey_F11)){
             debugStepBack = true;
         }
     }
-    if (ImGui::IsKeyPressed(ImGuiKey_F9)){
+
+    if (noMod && IsKeyPressed(ImGuiKey_F9)){
         toggleBreakpoint = true;
     }
-    if (IsKeyPressed(ImGuiKey_F3)){
-        runSelectedCode = true;
-    }
-    if (IsKeyPressed(ImGuiKey_F4)){
-        goToDefinition = true;
-    }
-    if (IsKeyPressed(ImGuiKey_F6)){
+    if (noMod && IsKeyPressed(ImGuiKey_F6)){
         debugPause = true;
     }
-    if (IsKeyPressed(ImGuiKey_F10)){
-        debugRun = true;
+    if (noMod && IsKeyPressed(ImGuiKey_F3)){
+        runSelectedCode = true;
+    }
+    if (noMod && IsKeyPressed(ImGuiKey_F4)){
+        goToDefinition = true;
     }
 
     if (isCtrlShiftShortcut && IsKeyPressed(ImGuiKey_Equal)) {

--- a/src/wasm-shell.html
+++ b/src/wasm-shell.html
@@ -79,6 +79,19 @@
     // it. Focus the canvas so it receives keyboard input immediately.
     window.addEventListener('load', () => canvas.focus());
 
+    // Capture the keys ZathuraDbg uses so the browser doesn't hijack them
+    // (F5 reload, F11 fullscreen, Ctrl+S "save page", Ctrl+O "open file", the
+    // step keys, etc.). preventDefault only cancels the browser's default
+    // action -- the keydown still reaches the wasm app. e.code is used so the
+    // checks are layout- and shift-independent. Ctrl+R / Ctrl+W are left alone
+    // so reload and close still work.
+    const ZATHURA_FN_KEYS = new Set(['F3','F4','F5','F6','F7','F9','F10','F11']);
+    const ZATHURA_MOD_KEYS = new Set(['KeyS','KeyO','KeyM','Period','Backquote','Equal','Minus','Digit0']);
+    window.addEventListener('keydown', (e) => {
+      if (ZATHURA_FN_KEYS.has(e.code)) { e.preventDefault(); return; }
+      if ((e.ctrlKey || e.metaKey) && ZATHURA_MOD_KEYS.has(e.code)) { e.preventDefault(); }
+    }, { capture: true });
+
     function showError(msg) {
       document.getElementById('error-text').textContent = msg;
       document.getElementById('error-box').style.display = 'flex';


### PR DESCRIPTION
`Ctrl+J` / `Ctrl+K` (step into / step over) collided with browser shortcuts (Chrome Downloads, the search bar), so stepping was flaky in the browser build. This moves to the **standard IDE keybinding scheme** (VS Code / Visual Studio) — which is also better for the native app — and adds a browser key-capture so the browser stops hijacking the app's keys.

## New keybindings

| Action | Key | Was |
|--------|-----|-----|
| Start debugging / Continue | `F5` | F5 |
| Stop | `Shift+F5` | Shift+F5 |
| Run without debugging | `Ctrl+F5` | F10 |
| Restart | `Ctrl+Shift+F5` | Ctrl+F5 |
| Step over | `F10` | Ctrl+K |
| Step into | `F11` | Ctrl+J |
| Step back (time-travel) | `Shift+F11` | Ctrl+B |
| Toggle breakpoint | `F9` | F9 |
| Pause | `F6` | F6 |

Toolbar tooltips and the Debug menu labels are updated to match. On macOS the modifier keys are Cmd (runtime-detected, from the earlier change).

## Browser key capture

`wasm-shell.html` adds a `keydown` listener that `preventDefault`s the keys the app uses (the F-keys, `Ctrl/Cmd+S/O/...`), so the browser no longer:
- reloads on `F5`, fullscreens on `F11`, opens Downloads on `Ctrl+J`,
- "saves the page" on `Ctrl+S`, "opens a file" on `Ctrl+O`, etc.

`preventDefault` only cancels the browser's default action — the keydown still reaches the wasm app. `Ctrl+R` / `Ctrl+W` are deliberately left alone so reload/close-tab still work. Checks use `e.code` so they're layout- and shift-independent.

## Verification
- Browser: `F5` starts debugging, `F10` steps (RIP advances, registers update), and the page does **not** reload on F5.
- Native build still compiles.
- Live: https://zathuradbg.pages.dev