### PR TITLE
Use HACKE-RC Keystone and improve executor stepping

### DIFF
--- a/src/app/actions/actions.cpp
+++ b/src/app/actions/actions.cpp
@@ -32,6 +32,56 @@ uint64_t remoteResumeGeneration = 0;
 
 static void syncRemoteUiState(bool refreshTarget, bool resetCodeMemoryBase);
 
+namespace {
+
+struct BreakpointLocation {
+    uint64_t address{};
+    uint64_t lineNo{};
+};
+
+bool ensureLocalAddressMapForBreakpoints()
+{
+    if (remote_gdb::useRemoteDebugging() || !addressLineNoMap.empty()) {
+        return true;
+    }
+
+    if (selectedFile.empty()) {
+        return false;
+    }
+
+    return !getBytes(selectedFile).empty();
+}
+
+std::optional<BreakpointLocation> resolveBreakpointLocationForEditorLine(const int editorLine)
+{
+    if (editorLine < 0) {
+        return std::nullopt;
+    }
+
+    if (!ensureLocalAddressMapForBreakpoints()) {
+        return std::nullopt;
+    }
+
+    const auto requestedLineNo = static_cast<uint64_t>(editorLine + 1);
+    std::optional<BreakpointLocation> best;
+
+    for (const auto& [address, lineNo] : addressLineNoMap) {
+        if (lineNo == requestedLineNo) {
+            return BreakpointLocation{address, lineNo};
+        }
+
+        if (lineNo > requestedLineNo &&
+            (!best.has_value() || lineNo < best->lineNo ||
+             (lineNo == best->lineNo && address < best->address))) {
+            best = BreakpointLocation{address, lineNo};
+        }
+    }
+
+    return best;
+}
+
+}
+
 void openBrowser(const std::string& url) {
 #ifdef __EMSCRIPTEN__
     EM_ASM({ window.open(UTF8ToString($0), '_blank'); }, url.c_str());
@@ -163,7 +213,8 @@ void stepBack()
 
     icicle_vm_restore(icicle, stateToRestore);
 
-    safeHighlightLine(addressLineNoMap[icicle_get_pc(icicle)] - 1);
+    const auto restoredLineIt = addressLineNoMap.find(icicle_get_pc(icicle));
+    safeHighlightLine(restoredLineIt != addressLineNoMap.end() ? static_cast<int>(restoredLineIt->second - 1) : -1);
     updateRegs(false);
 
     if (snapshot && snapshot != stateToRestore) {
@@ -402,7 +453,7 @@ bool debugAddBreakpointAddress(const uint64_t address) {
         if (!remote_gdb::remoteAddBreakpoint(address)) {
             return false;
         }
-    } else if (!addBreakpoint(address, false)) {
+    } else if (icicle != nullptr && !addBreakpoint(address, false)) {
         return false;
     }
 
@@ -426,7 +477,7 @@ bool debugRemoveBreakpointAddress(const uint64_t address) {
         if (!remote_gdb::remoteRemoveBreakpoint(address)) {
             return false;
         }
-    } else if (!removeBreakpoint(address)) {
+    } else if (icicle != nullptr && !removeBreakpoint(address)) {
         return false;
     }
 
@@ -516,45 +567,12 @@ void stepOverAction(){
             return;
         }
 
-        // It may cause issues if the actual line is 0 and not undefined. (Need to start from 1)
-        const uint64_t lineNo = addressLineNoMap[icicle_get_pc(icicle)];
-
-        if (lineNo){
-            
-            breakpointMutex.lock();
-            auto bpLineNoAddr = lineNoToAddress(lineNo + 1);
-            icicle_add_breakpoint(icicle, bpLineNoAddr);
-            breakpointLines.push_back(lineNo + 1); // Track the temporary breakpoint
-            breakpointMutex.unlock();
-
-            // Run until the next line (or breakpoint)
-            executeCode(icicle, 0); // Use executeCode which handles breakpoints
-
-            // Update UI with new position
-            if (!executionComplete) {
-                const uint64_t newLineNo = addressLineNoMap[icicle_get_pc(icicle)];
-                if (newLineNo)
-                    safeHighlightLine(newLineNo - 1);
-            }
-
-            // Attempt to remove the temporary breakpoint
-            breakpointMutex.lock();
-            icicle_remove_breakpoint(icicle, bpLineNoAddr);
-            auto it = std::ranges::find(breakpointLines, lineNo + 1);
-            if (it != breakpointLines.end()) {
-                 breakpointLines.erase(it);
-                 LOG_DEBUG("Removed step over breakpoint at line: " << lineNo + 1);
-            }
-            breakpointMutex.unlock();
-
-            // The old logic seems complex and potentially incorrect, replacing with simpler execute
-            stepOverBPLineNo = -1; // Clear any leftover state
-            LOG_INFO("Step over completed.");
-            continueOverBreakpoint = false; // Reset this flag
+        if (!stepOverCode()) {
+            consoleWriteThreadSafe("debug >> step-over failed\n");
         }
-        else {
-            LOG_WARNING("Could not get current line number for step over.");
-        }
+        stepOverBPLineNo = -1;
+        continueOverBreakpoint = false;
+        LOG_INFO("Step over completed.");
     });
     
 }
@@ -583,9 +601,9 @@ void stepInAction(){
         
         // Update UI after step is complete
         if (!executionComplete) {
-                const uint64_t newLineNo = addressLineNoMap[icicle_get_pc(icicle)];
-                if (newLineNo)
-                    safeHighlightLine(newLineNo - 1);
+            const auto lineIt = addressLineNoMap.find(icicle_get_pc(icicle));
+            if (lineIt != addressLineNoMap.end() && lineIt->second)
+                safeHighlightLine(lineIt->second - 1);
         }
         
         stepIn = false;
@@ -643,65 +661,43 @@ void debugToggleBreakpoint(){
 bool debugAddBreakpoint(const int lineNum){
     LOG_DEBUG("Adding breakpoint on the line " << lineNum);
 
-    if (remote_gdb::useRemoteDebugging()) {
-        if (std::ranges::find(breakpointLines, lineNum + 1) != breakpointLines.end()) {
-            return false;
-        }
-        const auto address = lineNoToAddress(lineNum + 1);
-        if (!address) {
-            consoleWriteThreadSafe("remote >> cannot resolve line to address for breakpoint\n");
-            return false;
-        }
-        return debugAddBreakpointAddress(address);
-    }
-
-    breakpointMutex.lock();
-
-    const auto breakpointLineNo = (std::ranges::find(breakpointLines, lineNum + 1));
-    if (breakpointLineNo != breakpointLines.end()){
-        LOG_DEBUG("Breakpoint already exists, skipping...");
-        breakpointMutex.unlock();
+    const auto location = resolveBreakpointLocationForEditorLine(lineNum);
+    if (!location.has_value()) {
+        consoleWriteThreadSafe(remote_gdb::useRemoteDebugging()
+            ? "remote >> cannot resolve line to address for breakpoint\n"
+            : "debug >> cannot resolve line to executable address for breakpoint\n");
         return false;
     }
-    else{
-        addBreakpointToLine(lineNum);
-        editor->HighlightBreakpoints(lineNum);
-        breakpointAddresses.push_back(lineNoToAddress(lineNum + 1));
-        LOG_DEBUG("Breakpoint added successfully!");
+
+    if (std::ranges::find(breakpointLines, location->lineNo) != breakpointLines.end() ||
+        std::ranges::find(breakpointAddresses, location->address) != breakpointAddresses.end()) {
+        LOG_DEBUG("Breakpoint already exists, skipping...");
+        return false;
     }
 
-    breakpointMutex.unlock();
-    return true;
+    const bool added = debugAddBreakpointAddress(location->address);
+    if (added) {
+        LOG_DEBUG("Breakpoint added successfully!");
+    }
+    return added;
 }
 
 bool debugRemoveBreakpoint(const int lineNum){
     LOG_DEBUG("Removing the breakpoint at " << lineNum);
-    const auto breakpointIter = (std::ranges::find(breakpointLines, lineNum + 1));
+    const auto location = resolveBreakpointLocationForEditorLine(lineNum);
 
-    if (breakpointIter == breakpointLines.end()){
+    if (!location.has_value() ||
+        std::ranges::find(breakpointLines, location->lineNo) == breakpointLines.end()){
         LOG_DEBUG("No breakpoint exists at line no. " << lineNum);
         return false;
     }
     else{
-        if (remote_gdb::useRemoteDebugging()) {
-            const auto address = lineNoToAddress(lineNum + 1);
-            if (!address) {
-                return false;
-            }
-            return debugRemoveBreakpointAddress(address);
+        const bool removed = debugRemoveBreakpointAddress(location->address);
+        if (removed) {
+            LOG_DEBUG("Removed breakpoint at line no. " << lineNum);
         }
-        if (!removeBreakpointFromLineNo(lineNum + 1)) {
-            return false;
-        }
-        const auto address = lineNoToAddress(lineNum + 1);
-        const auto addressIter = std::ranges::find(breakpointAddresses, address);
-        if (addressIter != breakpointAddresses.end()) {
-            breakpointAddresses.erase(addressIter);
-        }
-        LOG_DEBUG("Removed breakpoint at line no. " << lineNum);
+        return removed;
     }
-
-    return true;
 }
 
 void debugRunSelectionAction(){
@@ -766,12 +762,14 @@ void debugContinueAction(const bool skipBP) {
         
         // Update UI after execution
         if (!executionComplete) {
-                const uint64_t newLineNo = addressLineNoMap[icicle_get_pc(icicle)];
-                if (newLineNo)
-                    safeHighlightLine(newLineNo - 1);
+            const auto lineIt = addressLineNoMap.find(icicle_get_pc(icicle));
+            if (lineIt != addressLineNoMap.end() && lineIt->second)
+                safeHighlightLine(lineIt->second - 1);
         }
-        else
-            safeHighlightLine(lastInstructionLineNo - 1);
+        else {
+            const int currentLine = getCurrentLine();
+            safeHighlightLine(currentLine > 0 ? currentLine - 1 : (lastInstructionLineNo > 0 ? static_cast<int>(lastInstructionLineNo - 1) : -1));
+        }
 
         skipBreakpoints = false;
         runningAsContinue = false;
@@ -889,9 +887,9 @@ void runActions(){
                 skipEndStep = false;
 
                 if (!executionComplete) {
-                    const uint64_t newLineNo = addressLineNoMap[icicle_get_pc(icicle)];
-                    if (newLineNo)
-                        safeHighlightLine(newLineNo - 1);
+                    const auto lineIt = addressLineNoMap.find(icicle_get_pc(icicle));
+                    if (lineIt != addressLineNoMap.end() && lineIt->second)
+                        safeHighlightLine(lineIt->second - 1);
                 }
                 
                 // Remove temporary breakpoint
@@ -947,7 +945,8 @@ void runActions(){
                 // Execution was successful
                 // Update UI after run
                 if (executionComplete) {
-                    safeHighlightLine(lastInstructionLineNo - 1);
+                    const int currentLine = getCurrentLine();
+                    safeHighlightLine(currentLine > 0 ? currentLine - 1 : (lastInstructionLineNo > 0 ? static_cast<int>(lastInstructionLineNo - 1) : -1));
                 }
             }
             else {

--- a/src/app/arch/arch.cpp
+++ b/src/app/arch/arch.cpp
@@ -1,7 +1,7 @@
 #include "arch.hpp"
 
 #include <windows.hpp>
-codeInformationT codeInformation{.archIC=IC_ARCH_X86_64, .archKS = KS_ARCH_X86,  .archCS = CS_ARCH_X86, .mode=UC_MODE_64, .modeKS = KS_MODE_64,.modeCS = CS_MODE_64, .syntax = KS_OPT_SYNTAX_INTEL, .archStr = "x86_64"};
+codeInformationT codeInformation{.archIC=IC_ARCH_X86_64, .archKS = KS_ARCH_X86,  .archCS = CS_ARCH_X86, .mode=UC_MODE_64, .modeKS = KS_MODE_64,.modeCS = CS_MODE_64, .syntax = KS_OPT_SYNTAX_NASM, .archStr = "x86_64"};
 // codeInformationT codeInformation{.archIC=IC_ARCH_ARM, .archKS = KS_ARCH_ARM,  .archCS = CS_ARCH_ARM, .modeKS = KS_MODE_LITTLE_ENDIAN,.modeCS = CS_MODE_LITTLE_ENDIAN, .syntax = KS_OPT_SYNTAX_NASM, .archStr = "aarch64"};
 std::unordered_map<std::string, size_t> regInfoMap = {};
 std::string (*getArchIPStr)() = nullptr;

--- a/src/app/buttons.cpp
+++ b/src/app/buttons.cpp
@@ -88,7 +88,7 @@ bool setupButtons() {
 
          if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Run (F10)");
+            ImGui::Text("Run (Ctrl+F5)");
             ImGui::EndTooltip();
         }
 
@@ -114,7 +114,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Restart Debugging (CTRL+F5)");
+            ImGui::Text("Restart Debugging (Ctrl+Shift+F5)");
             ImGui::EndTooltip();
         }
 
@@ -142,7 +142,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Step Over (CTRL+K)");
+            ImGui::Text("Step Over (F10)");
             ImGui::EndTooltip();
         }
 
@@ -156,7 +156,7 @@ bool setupButtons() {
 
         if (ImGui::IsItemHovered()) {
             ImGui::BeginTooltip();
-            ImGui::Text("Step In (CTRL+J)");
+            ImGui::Text("Step In (F11)");
             ImGui::EndTooltip();
         }
 
@@ -219,7 +219,7 @@ bool setupButtons() {
     }
     if (ImGui::IsItemHovered()) {
         ImGui::BeginTooltip();
-        ImGui::Text("Restart Debugging (CTRL+F5)");
+        ImGui::Text("Restart Debugging (Ctrl+Shift+F5)");
         ImGui::EndTooltip();
     }
     const char* targetLabel = remote_gdb::useRemoteDebugging() ? "Server" : "Emulation";

--- a/src/app/integration/interpreter/breakpoints.cpp
+++ b/src/app/integration/interpreter/breakpoints.cpp
@@ -3,16 +3,17 @@
 bool removeBreakpoint(const uint64_t& address) {
     std::lock_guard<std::mutex> lock(breakpointMutex);
 
-    bool success = false;
-    if (breakpointLines.empty()) {
-        return success;
+    bool success = true;
+    if (icicle != nullptr) {
+        icicle_remove_breakpoint(icicle, address);
     }
 
-    const auto it = std::ranges::find(breakpointLines, addressLineNoMap[address]);
-    if  (it != breakpointLines.end()) {
-        icicle_remove_breakpoint(icicle, address);
-        breakpointLines.erase(it);
-        success = true;
+    const auto lineIt = addressLineNoMap.find(address);
+    if (lineIt != addressLineNoMap.end()) {
+        const auto it = std::ranges::find(breakpointLines, lineIt->second);
+        if  (it != breakpointLines.end()) {
+            breakpointLines.erase(it);
+        }
     }
 
     return success;

--- a/src/app/integration/interpreter/execution.cpp
+++ b/src/app/integration/interpreter/execution.cpp
@@ -1,6 +1,118 @@
 #include "interpreter.hpp"
 #include "../debugState.hpp"
+#include <capstone/capstone.h>
 #include <algorithm>
+
+namespace {
+
+int sourceLineIndexForAddress(const uint64_t address)
+{
+    const auto lineIt = addressLineNoMap.find(address);
+    return lineIt != addressLineNoMap.end() && lineIt->second > 0
+        ? static_cast<int>(lineIt->second - 1)
+        : -1;
+}
+
+int fallbackLastSourceLineIndex()
+{
+    return lastInstructionLineNo > 0 ? static_cast<int>(lastInstructionLineNo - 1) : -1;
+}
+
+bool isAtCodeEnd(const uint64_t address)
+{
+    const auto endAddress = codeEndAddress();
+    return endAddress != 0 && address == endAddress;
+}
+
+bool currentInstructionIsCall(const uint64_t address, uint64_t& fallthroughAddress)
+{
+    fallthroughAddress = 0;
+
+    const auto endAddress = codeEndAddress();
+    if (icicle == nullptr || endAddress == 0 || address >= endAddress)
+    {
+        return false;
+    }
+
+    const auto maxRead = static_cast<size_t>(std::min<uint64_t>(16, endAddress - address));
+    size_t outSize = 0;
+    unsigned char* bytes = icicle_mem_read(icicle, address, maxRead, &outSize);
+    if (bytes == nullptr || outSize == 0)
+    {
+        if (bytes != nullptr)
+        {
+            icicle_free_buffer(bytes, outSize);
+        }
+        LOG_ERROR("Unable to read current instruction for step-over.");
+        return false;
+    }
+
+    csh handle = 0;
+    if (cs_open(codeInformation.archCS, codeInformation.modeCS, &handle) != CS_ERR_OK)
+    {
+        icicle_free_buffer(bytes, outSize);
+        LOG_ERROR("Unable to open Capstone for step-over instruction classification.");
+        return false;
+    }
+
+    cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
+
+    cs_insn* instruction = nullptr;
+    const size_t count = cs_disasm(handle, bytes, outSize, address, 1, &instruction);
+    icicle_free_buffer(bytes, outSize);
+
+    bool isCall = false;
+    if (count > 0)
+    {
+        fallthroughAddress = instruction[0].address + instruction[0].size;
+        isCall = cs_insn_group(handle, &instruction[0], CS_GRP_CALL);
+    }
+    else
+    {
+        LOG_ERROR("Unable to disassemble current instruction for step-over.");
+    }
+
+    cs_free(instruction, count);
+    cs_close(&handle);
+    return isCall;
+}
+
+void installStoredBreakpoints()
+{
+    if (icicle == nullptr)
+    {
+        return;
+    }
+
+    std::vector<uint64_t> resolvedAddresses;
+
+    for (const auto lineNo : breakpointLines)
+    {
+        const auto address = lineNoToAddress(lineNo);
+        if (address != 0 && std::ranges::find(resolvedAddresses, address) == resolvedAddresses.end())
+        {
+            resolvedAddresses.push_back(address);
+        }
+    }
+
+    for (const auto address : breakpointAddresses)
+    {
+        const bool isSourceMapped = addressLineNoMap.find(address) != addressLineNoMap.end();
+        if (!isSourceMapped && address != 0 && std::ranges::find(resolvedAddresses, address) == resolvedAddresses.end())
+        {
+            resolvedAddresses.push_back(address);
+        }
+    }
+
+    breakpointAddresses = resolvedAddresses;
+
+    for (const auto address : breakpointAddresses)
+    {
+        icicle_add_breakpoint(icicle, address);
+    }
+}
+
+}
 
 int getCurrentLine(){
     uint64_t instructionPointer = -1;
@@ -14,9 +126,8 @@ int getCurrentLine(){
         return -1;
     }
 
-    const auto lineNumber = addressLineNoMap[instructionPointer];
-
-    return (lineNumber ? lineNumber : -1);
+    const auto lineIt = addressLineNoMap.find(instructionPointer);
+    return lineIt != addressLineNoMap.end() && lineIt->second ? static_cast<int>(lineIt->second) : -1;
 }
 
 int handleSyscalls(void* data, uint64_t syscall_nr, const SyscallArgs* args)
@@ -49,9 +160,9 @@ int handleSyscalls(void* data, uint64_t syscall_nr, const SyscallArgs* args)
 void instructionHook(void* userData, const uint64_t address)
 {
 
-    const uint64_t lineNo = addressLineNoMap[address];
-    if (lineNo > 0)
-        safeHighlightLine(lineNo - 1);
+    const auto lineIndex = sourceLineIndexForAddress(address);
+    if (lineIndex >= 0)
+        safeHighlightLine(lineIndex);
 
     if (ttdEnabled)
     {
@@ -134,6 +245,7 @@ bool preExecutionSetup(const std::string& codeIn)
     uint32_t stackWriteHookID = icicle_add_mem_write_hook(icicle, stackWriteHook, nullptr, STACK_ADDRESS, STACK_ADDRESS + STACK_SIZE);
     icicle_add_syscall_hook(icicle, handleSyscalls, icicle);
     installDebugWatchpointHooks();
+    installStoredBreakpoints();
 
     // Signal that debugging setup is complete and ready for execution
     {
@@ -162,6 +274,11 @@ uint64_t lineNoToAddress(const uint64_t& lineNo)
     return 0;
 }
 
+uint64_t codeEndAddress()
+{
+    return codeExecutableEndAddress;
+}
+
 bool isCodeExecutedAlready = false;
 bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, const uint64_t& oldBPAddr)
 {
@@ -169,27 +286,32 @@ bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, co
     LOG_INFO("Execution completed! with status code: " << status << " address: " << std::hex << ip);
 
 
-    const uint64_t lineNo = addressLineNoMap[ip];
-    if (lineNo > 0)
-        safeHighlightLine(lineNo - 1);
+    const auto lineIndex = sourceLineIndexForAddress(ip);
+    if (lineIndex >= 0)
+        safeHighlightLine(lineIndex);
 
+    if (isAtCodeEnd(ip))
+    {
+        icicle_remove_breakpoint(icicle, ip);
+        isEndBreakpointSet = false;
+        executionComplete = true;
+        stoppedAtBreakpoint = false;
+        safeHighlightLine(fallbackLastSourceLineIndex());
+        return true;
+    }
 
     if (status == RunStatus::Breakpoint)
     {
         LOG_DEBUG("Breakpoint reached at address " << icicle_get_pc(icicle));
 
-        const uint64_t lineNo = addressLineNoMap[ip];
+        const auto lineIt = addressLineNoMap.find(ip);
+        const uint64_t lineNo = lineIt != addressLineNoMap.end() ? lineIt->second : 0;
         if (lineNo)
         {
             if (isSilentBreakpoint(lineNo))
             {
-                auto s = icicle_remove_breakpoint(icicle, ip);
-                if (!skipEndStep)
-                {
-                    status = icicle_step(icicle, 1);
-                    executionComplete = true;
-                    stoppedAtBreakpoint = false;
-                }
+                icicle_remove_breakpoint(icicle, ip);
+                stoppedAtBreakpoint = false;
             }
             else
             {
@@ -223,6 +345,11 @@ bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, co
     {
         LOG_DEBUG("Unhandled exception. Code :" << icicle_get_exception_code(icicle));
         return false;
+    }
+    else if (status == RunStatus::Halt)
+    {
+        executionComplete = true;
+        stoppedAtBreakpoint = false;
     }
 
     if (addBreakpointBack)
@@ -280,9 +407,14 @@ static bool executeCodeCore(Icicle* icicle, const size_t& instructionCount)
 
     if (instructionCount == 0)
     {
-        if (!icicle_add_breakpoint(icicle, lineNoToAddress(lastInstructionLineNo)) && !isEndBreakpointSet)
+        const auto endAddress = codeEndAddress();
+        if (endAddress == 0)
         {
-           LOG_ERROR("Failed to add breakpoint at the last instruction. The program may end unexpectedly.");
+           LOG_ERROR("Cannot add end breakpoint before code has been assembled.");
+        }
+        else if (!icicle_add_breakpoint(icicle, endAddress) && !isEndBreakpointSet)
+        {
+           LOG_ERROR("Failed to add breakpoint at the end of the assembled code. The program may end unexpectedly.");
         }
         else
         {
@@ -308,11 +440,6 @@ static bool executeCodeCore(Icicle* icicle, const size_t& instructionCount)
     }
     else
     {
-        if (!icicle_add_breakpoint(icicle, lineNoToAddress(lastInstructionLineNo)))
-        {
-            LOG_ERROR("Failed to add breakpoint at the last instruction. The program may end unexpectedly.");
-        }
-
        status = icicle_step(icicle, instructionCount);
     }
 
@@ -351,11 +478,14 @@ bool stepCode(const size_t instructionCount){
 
     // Update state *after* execution
     ip = icicle_get_pc(icicle);
-    safeHighlightLine(addressLineNoMap[icicle_get_pc(icicle)]);
     isCodeRunning = false; // Mark as not running *after* execution
 
     if (executionComplete){
-        safeHighlightLine(lastInstructionLineNo-1);
+        const auto lineIt = addressLineNoMap.find(ip);
+        const int highlightLine = lineIt != addressLineNoMap.end()
+            ? static_cast<int>(lineIt->second - 1)
+            : (lastInstructionLineNo > 0 ? static_cast<int>(lastInstructionLineNo - 1) : -1);
+        safeHighlightLine(highlightLine);
         LOG_DEBUG("Execution complete after step.");
         return true;
     }
@@ -379,10 +509,10 @@ bool stepCode(const size_t instructionCount){
             expectedIP = ip;
         }
 
-        const uint64_t lineNo =  addressLineNoMap[ip];
-        if (lineNo && !executionComplete){
-            LOG_DEBUG("Highlight from stepCode : line: " << lineNo);
-            safeHighlightLine(lineNo - 1);
+        const auto lineIndex = sourceLineIndexForAddress(ip);
+        if (lineIndex >= 0 && !executionComplete){
+            LOG_DEBUG("Highlight from stepCode : line: " << lineIndex + 1);
+            safeHighlightLine(lineIndex);
         }
         else{
              LOG_DEBUG("No line number found for current IP or execution complete.");
@@ -403,6 +533,88 @@ bool stepCode(const size_t instructionCount){
     return true;
 }
 
+bool stepOverCode()
+{
+    LOG_DEBUG("Semantic step-over requested...");
+
+    waitForDebugReady();
+    LOG_DEBUG("Debug state confirmed ready, proceeding with semantic step-over.");
+
+    std::lock_guard<std::mutex> execLock(execMutex);
+
+    if (icicle == nullptr)
+    {
+        LOG_ERROR("Attempted to step over code when icicle was not initialised!");
+        return false;
+    }
+
+    if (isCodeRunning || executionComplete)
+    {
+        LOG_DEBUG("Step-over request ignored: Code already running or execution complete.");
+        return true;
+    }
+
+    const uint64_t currentAddress = icicle_get_pc(icicle);
+    uint64_t fallthroughAddress = 0;
+
+    if (!currentInstructionIsCall(currentAddress, fallthroughAddress))
+    {
+        isCodeRunning = true;
+        const bool ok = executeCodeCore(icicle, 1);
+        isCodeRunning = false;
+        return ok;
+    }
+
+    if (fallthroughAddress == 0)
+    {
+        LOG_ERROR("Current call instruction has no fallthrough address; falling back to step-in.");
+        isCodeRunning = true;
+        const bool ok = executeCodeCore(icicle, 1);
+        isCodeRunning = false;
+        return ok;
+    }
+
+    if (isAtCodeEnd(fallthroughAddress))
+    {
+        isCodeRunning = true;
+        const bool ok = executeCodeCore(icicle, 0);
+        isCodeRunning = false;
+        return ok;
+    }
+
+    bool tempBreakpointAdded = false;
+    {
+        std::lock_guard<std::mutex> breakpointLock(breakpointMutex);
+        tempBreakpointAdded = icicle_add_breakpoint(icicle, fallthroughAddress);
+    }
+
+    if (!tempBreakpointAdded)
+    {
+        LOG_DEBUG("Step-over fallthrough breakpoint already existed or could not be added.");
+    }
+
+    isCodeRunning = true;
+    const bool ok = executeCodeCore(icicle, 0);
+    isCodeRunning = false;
+
+    if (tempBreakpointAdded)
+    {
+        std::lock_guard<std::mutex> breakpointLock(breakpointMutex);
+        icicle_remove_breakpoint(icicle, fallthroughAddress);
+    }
+
+    if (!executionComplete)
+    {
+        const auto lineIndex = sourceLineIndexForAddress(icicle_get_pc(icicle));
+        if (lineIndex >= 0)
+        {
+            safeHighlightLine(lineIndex);
+        }
+    }
+
+    return ok;
+}
+
 
 bool runCode(const std::string& codeIn, const bool& execCode)
 {
@@ -421,17 +633,16 @@ bool runCode(const std::string& codeIn, const bool& execCode)
     safeHighlightLine(val - 1);
 
     if (execCode || (stepClickedOnce)){
-        if (addBreakpointToLine(lastInstructionLineNo, true))
-        {
-            isEndBreakpointSet = true;
-        }
-
         if (!executeCodeCore(icicle, 0))
         {
             LOG_ERROR("Failed to run code.");
         }
 
-        safeHighlightLine(lastInstructionLineNo);
+        const auto lineIndex = sourceLineIndexForAddress(icicle_get_pc(icicle));
+        if (lineIndex >= 0)
+        {
+            safeHighlightLine(lineIndex);
+        }
         if (runningTempCode){
             // icicle_vm_snapshot(icicle);
             updateRegs();

--- a/src/app/integration/interpreter/interpreter.hpp
+++ b/src/app/integration/interpreter/interpreter.hpp
@@ -107,6 +107,7 @@ extern bool setRegisterValue(const std::string& regName, const registerValueT& v
 extern bool initRegistersToDefinedVals();
 extern bool runCode(const std::string& codeIn, const bool& execCode);
 extern uint64_t lineNoToAddress(const uint64_t& lineNo);
+extern uint64_t codeEndAddress();
 extern bool addBreakpoint(const uint64_t& address, const bool& silent);
 extern bool stoppedAtBreakpoint;
 extern bool nextLineHasBreakpoint;
@@ -125,6 +126,7 @@ extern uintptr_t STACK_SIZE;
 extern int tempBPLineNum;
 extern uint64_t CODE_BUF_SIZE;
 extern bool stepCode(size_t instructionCount = 1);
+extern bool stepOverCode();
 extern std::vector<uint64_t> breakpointLines;
 extern std::vector<uint64_t> breakpointAddresses;
 extern bool resetState(bool reInit = true);

--- a/src/app/integration/interpreter/vm.cpp
+++ b/src/app/integration/interpreter/vm.cpp
@@ -54,16 +54,6 @@ Icicle* initIC()
     LOG_INFO("Initiation complete...");
     initArch();
 
-
-    if (!breakpointLines.empty())
-    {
-        for (auto& line : breakpointLines)
-        {
-            // addBreakpointToLine(line);
-            icicle_add_breakpoint(vm, lineNoToAddress(line));
-        }
-    }
-
     icicle = vm;
     return vm;
 }
@@ -170,6 +160,7 @@ bool resetState(bool reInit){
 
     codeCurrentLen = 0;
     codeFinalLen = 0;
+    codeExecutableEndAddress = 0;
     lineNo = 0;
     expectedIP = 0;
 

--- a/src/app/integration/keystone/assembler.cpp
+++ b/src/app/integration/keystone/assembler.cpp
@@ -120,8 +120,11 @@ bool isValidInstruction(ks_engine* ksEngine, const char* instruction) {
 }
 
 uint64_t lastInstructionLineNo = 0;
+uint64_t codeExecutableEndAddress = 0;
 void initInsSizeInfoMap(){
     LOG_INFO("Updating instruction sizes info map...");
+    lastInstructionLineNo = 0;
+    codeExecutableEndAddress = 0;
     
     if (instructionSizes.empty() && codeInformation.archIC != IC_ARCH_AARCH64) {
         LOG_ERROR("instructionSizes is empty! Cannot initialize instruction size info map.");
@@ -181,16 +184,19 @@ void initInsSizeInfoMap(){
 
 
         if (isValidInstruction(ks, line.c_str()) || (codeInformation.archIC == IC_ARCH_AARCH64 && instructionStr.contains('.'))){
-             if (labels.size() <= 1)
-                lastInstructionLineNo = lineNo;
+            lastInstructionLineNo = lineNo;
 
             addressLineNoMap.insert({currentAddr, lineNo});
             if (codeInformation.archIC == IC_ARCH_AARCH64)
+            {
                 currentAddr += 4; // every instruction in aarch64 is 4 bytes long
+                codeExecutableEndAddress = currentAddr;
+            }
             else
             {
                 if (count < instructionSizes.size()) {
                     currentAddr += instructionSizes[count];
+                    codeExecutableEndAddress = currentAddr;
                 } else {
                     std::cerr << "instructionSizes out-of-bounds: count = " << count
                               << ", instructionSizes.size() = " << instructionSizes.size()

--- a/src/app/integration/keystone/assembler.hpp
+++ b/src/app/integration/keystone/assembler.hpp
@@ -26,6 +26,7 @@ typedef struct{
 
 extern uint64_t totalInstructions;
 extern uint64_t lastInstructionLineNo;
+extern uint64_t codeExecutableEndAddress;
 extern std::unordered_map<uint64_t, uint64_t> addressLineNoMap;
 extern std::map<std::string, int> labelLineNoMapInternal;
 

--- a/src/app/menuBar.cpp
+++ b/src/app/menuBar.cpp
@@ -337,10 +337,10 @@ void appMenuBar()
                 ImGui::MenuItem("Stop debugging", "Shift+F5", &debugStop);
             }
             ImGui::MenuItem("Configure target", nullptr, &showDebugTargetSettings);
-            ImGui::MenuItem("Step In", "CTRL+J", &debugStepIn, debugModeEnabled ? true : false);
-            ImGui::MenuItem("Step Over", "CTRL+K", &debugStepOver, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Step Over", "F10", &debugStepOver, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Step In", "F11", &debugStepIn, debugModeEnabled ? true : false);
             ImGui::MenuItem("Continue", debugModeEnabled ? "F5" : nullptr, &debugContinue, debugModeEnabled ? true : false);
-            ImGui::MenuItem("Restart debugging", "CTRL+F5", &debugRestart, debugModeEnabled ? true : false);
+            ImGui::MenuItem("Restart debugging", "Ctrl+Shift+F5", &debugRestart, debugModeEnabled ? true : false);
             ImGui::MenuItem("Memory maps", "CTRL+F7", &memoryMapsUI, debugModeEnabled ? true : false);
             ImGui::MenuItem("Breakpoints", nullptr, &breakpointsUI, true);
             ImGui::MenuItem("Watchpoints", nullptr, &watchpointsUI, true);

--- a/src/app/shortcuts.cpp
+++ b/src/app/shortcuts.cpp
@@ -47,48 +47,69 @@ void manageShortcuts(){
         use32BitLanes = !use32BitLanes;
         updateRegistersOnLaneChange();
     }
-    if (isShiftOnly && (ImGui::IsKeyPressed(ImGuiKey_F5))){
+    const auto noMod = !alt && !ctrl && !shift && !super;
+
+    // --- Debugger controls: standard IDE keys (VS Code / Visual Studio) ------
+    // These avoid the Ctrl+J/Ctrl+K bindings that browsers steal (Downloads,
+    // search bar) and match what developers expect everywhere.
+    //
+    //   F5            Start debugging / Continue
+    //   Shift+F5      Stop
+    //   Ctrl+F5       Run without debugging
+    //   Ctrl+Shift+F5 Restart
+    //   F10           Step over
+    //   F11           Step into
+    //   Shift+F11     Step back (time-travel)
+    //   F9            Toggle breakpoint
+    //   F6            Pause
+    if (isShiftOnly && IsKeyPressed(ImGuiKey_F5)){
         if (debugModeEnabled){
             debugStop = true;
         }
         return;
     }
-    else if (ImGui::IsKeyPressed(ImGuiKey_F5)){
+    if (isCtrlShiftShortcut && IsKeyPressed(ImGuiKey_F5)){
+        if (debugModeEnabled){
+            debugRestart = true;
+        }
+        return;
+    }
+    if (isCtrlShortcut && IsKeyPressed(ImGuiKey_F5)){
+        debugRun = true;
+        return;
+    }
+    if (noMod && IsKeyPressed(ImGuiKey_F5)){
         if (!debugModeEnabled){
             enableDebugMode = true;
-        }
-        else if ((isCtrlShortcut) &&ImGui::IsKeyPressed(ImGuiKey_F5)){
-            debugRestart = true;
         }
         else{
             debugContinue = true;
         }
     }
+
     if (debugModeEnabled){
-        if (isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_J))){
-            debugStepIn = true;
-        }
-        if (isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_K))){
+        if (noMod && IsKeyPressed(ImGuiKey_F10)){
             debugStepOver = true;
         }
-        if (ttdEnabled && isCtrlShortcut && (ImGui::IsKeyPressed(ImGuiKey_B))){
+        if (noMod && IsKeyPressed(ImGuiKey_F11)){
+            debugStepIn = true;
+        }
+        if (ttdEnabled && isShiftOnly && IsKeyPressed(ImGuiKey_F11)){
             debugStepBack = true;
         }
     }
-    if (ImGui::IsKeyPressed(ImGuiKey_F9)){
+
+    if (noMod && IsKeyPressed(ImGuiKey_F9)){
         toggleBreakpoint = true;
     }
-    if (IsKeyPressed(ImGuiKey_F3)){
-        runSelectedCode = true;
-    }
-    if (IsKeyPressed(ImGuiKey_F4)){
-        goToDefinition = true;
-    }
-    if (IsKeyPressed(ImGuiKey_F6)){
+    if (noMod && IsKeyPressed(ImGuiKey_F6)){
         debugPause = true;
     }
-    if (IsKeyPressed(ImGuiKey_F10)){
-        debugRun = true;
+    if (noMod && IsKeyPressed(ImGuiKey_F3)){
+        runSelectedCode = true;
+    }
+    if (noMod && IsKeyPressed(ImGuiKey_F4)){
+        goToDefinition = true;
     }
 
     if (isCtrlShiftShortcut && IsKeyPressed(ImGuiKey_Equal)) {

--- a/src/app/tasks/fileTasks.cpp
+++ b/src/app/tasks/fileTasks.cpp
@@ -154,6 +154,7 @@ bool deserializeState()
     }
 
     LOG_INFO("Successfully deserialized from file " << fileName);
-    safeHighlightLine(addressLineNoMap[icicle_get_pc(icicle)]);
+    const auto lineIt = addressLineNoMap.find(icicle_get_pc(icicle));
+    safeHighlightLine(lineIt != addressLineNoMap.end() && lineIt->second ? static_cast<int>(lineIt->second - 1) : -1);
     return true;
 }

--- a/src/scripts/wasm/build-wasm-deps.sh
+++ b/src/scripts/wasm/build-wasm-deps.sh
@@ -46,6 +46,7 @@ if [[ ! -f "$WASM_LIBS_ROOT/keystone-src/build-wasm/llvm/lib/libkeystone.a" ]]; 
     rm -rf "$WASM_LIBS_ROOT/keystone-src"
     cp -r "$REPO_DIR/vendor/keystone" "$WASM_LIBS_ROOT/keystone-src"
     emcmake cmake -S "$WASM_LIBS_ROOT/keystone-src" -B "$WASM_LIBS_ROOT/keystone-src/build-wasm" \
+        -DCMAKE_POLICY_VERSION_MINIMUM=3.5 \
         -DCMAKE_BUILD_TYPE=Release -DBUILD_SHARED_LIBS=OFF \
         -DLLVM_TARGETS_TO_BUILD="X86;AArch64;ARM" -DBUILD_LIBS_ONLY=ON
     cmake --build "$WASM_LIBS_ROOT/keystone-src/build-wasm" -j"$(nproc)"

--- a/src/test.asm
+++ b/src/test.asm
@@ -1,38 +1,31 @@
-main:
-	mov rbx, 0x400
-	movabs rax, 0x4010000000000000
-	movq xmm0, rax
-	punpcklqdq xmm0, xmm0
-	add rbx, rax
-	mov rdi, rbx
-	inc rdi
-    call subtract_hundred
-    call subtract_hundred
-    cmp r11, 10000
-    jne nextblock
-    push rax
-    push rbx
-    mov rax, 0x100
-    
-subtract_hundred:
-    sub rdi, 0x100
-    mov rax, rdi
-    mov rbx, 0x12
+bits 64
+default rel
+
+section .text
+_start:
+    mov rax, 1
+    mov rdi, 1
+    lea rsi, [message]
+    mov rdx, message_len
+    syscall
+
+    mov rcx, 5
+    xor rbx, rbx
+
+count:
+    add rbx, rcx
+    loop count
+
+    call double_result
+
+    mov rax, 60
+    xor rdi, rdi
+    syscall
+
+double_result:
+    add rbx, rbx
     ret
 
-nextblock:
-	mov rax, rbx
-	jmp nextblockagain
-
-nextblockagain:
-	mov rbx, rcx
-	jmp nextblocktwice
-
-nextblocktwice:
-	mov rdx, rcx
-	jmp anewblock
-
-anewblock:
-	mov r8, r9
-	inc r11
-	jmp main
+section .data
+message: db "Hello from ZathuraDbg", 10
+message_len equ $ - message

--- a/src/wasm-shell.html
+++ b/src/wasm-shell.html
@@ -79,6 +79,19 @@
     // it. Focus the canvas so it receives keyboard input immediately.
     window.addEventListener('load', () => canvas.focus());
 
+    // Capture the keys ZathuraDbg uses so the browser doesn't hijack them
+    // (F5 reload, F11 fullscreen, Ctrl+S "save page", Ctrl+O "open file", the
+    // step keys, etc.). preventDefault only cancels the browser's default
+    // action -- the keydown still reaches the wasm app. e.code is used so the
+    // checks are layout- and shift-independent. Ctrl+R / Ctrl+W are left alone
+    // so reload and close still work.
+    const ZATHURA_FN_KEYS = new Set(['F3','F4','F5','F6','F7','F9','F10','F11']);
+    const ZATHURA_MOD_KEYS = new Set(['KeyS','KeyO','KeyM','Period','Backquote','Equal','Minus','Digit0']);
+    window.addEventListener('keydown', (e) => {
+      if (ZATHURA_FN_KEYS.has(e.code)) { e.preventDefault(); return; }
+      if ((e.ctrlKey || e.metaKey) && ZATHURA_MOD_KEYS.has(e.code)) { e.preventDefault(); }
+    }, { capture: true });
+
     function showError(msg) {
       document.getElementById('error-text').textContent = msg;
       document.getElementById('error-box').style.display = 'flex';

--- a/vendor/keystone/CMakeLists.txt
+++ b/vendor/keystone/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Keystone Assembler Engine (www.keystone-engine.org)
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8.7)
 project(keystone)
 
 set(KEYSTONE_VERSION_MAJOR 0)
@@ -20,6 +20,11 @@ if (POLICY CMP0022)
 endif()
 
 if (POLICY CMP0051)
+  # CMake 3.1 and higher include generator expressions of the form
+  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+  # stripped everywhere that access the SOURCES property, so we just
+  # defer to the OLD behavior of not including generator expressions
+  # in the output for now.
   cmake_policy(SET CMP0051 NEW)
 endif()
 

--- a/vendor/keystone/README.md
+++ b/vendor/keystone/README.md
@@ -20,6 +20,46 @@ Keystone is based on LLVM, but it goes much further with [a lot more to offer](/
 Further information is available at http://www.keystone-engine.org
 
 
+This fork
+---------
+
+This is a maintained fork of [keystone-engine/keystone](https://github.com/keystone-engine/keystone)
+(upstream has had no commits since May 2023). It builds on modern toolchains and
+substantially completes the x86 **NASM** dialect, with fixes verified
+byte-for-byte against the NASM assembler, by the regression suite, and by
+executing the assembled code in the [Unicorn](https://github.com/unicorn-engine/unicorn)
+CPU emulator.
+
+**Build / toolchain**
+- Compiles with current CMake (CMP0051) and libstdc++ (`<cstdint>`).
+
+**NASM syntax (x86)**
+- Data: string literals in `db`/`dw`/`dd`/`dq`, float literals in `dd`/`dq`/`dt`
+  (IEEE single / double / 80-bit), `dt`/`do`/`dy`/`dz`, and `resb`/`resw`/`resd`/`resq`/...
+- Directives / pseudo-ops: `times`, `equ`, `align`, `extern`, `org`,
+  `section`/`segment`, the `$` and `$$` location counters, and `0o`/`0q` octal
+  and `0y` binary integer prefixes.
+- Decimal is now the default radix (it was forcing hex — `db 12` produced `0x12`);
+  hex stays opt-in via `KS_OPT_SYNTAX_RADIX16`.
+- The boot-sector idiom `times 510-($-$$) db 0` works via a layout-time fill — a
+  full 512-byte boot sector (and a 16→32-bit protected-mode switch with a
+  GDT built from data directives) assembles and boots in Unicorn.
+
+**Assembler bug fixes (x86)**
+- `push word imm16` no longer loses the `0x66` prefix (matched `PUSHi32`).
+- `[rax+rsp]` / `[rbx+rsp*1]` no longer encode RSP as an illegal SIB index (swapped to base).
+- Symbol differences in memory displacements (`lea eax, [eax+b-a]`) resolve correctly.
+- Segment overrides inside brackets (`[es:0x10]`, `[fs:eax]`) are accepted.
+- Symbol-resolver call/jmp displacement is no longer off by 4.
+- Spurious `0x66` operand-size prefix removed from `ret`/`retf`/`iret`/`pushf`/`popf`
+  and 16-bit `push`/`call imm` in Intel/NASM syntax.
+
+See `suite/regress/` (notably `x86_emulate_directives.py`, which runs the output
+in Unicorn) for the tests covering these.
+
+Further information is available at http://www.keystone-engine.org
+
+
 License
 -------
 

--- a/vendor/keystone/kstool/CMakeLists.txt
+++ b/vendor/keystone/kstool/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Kstool for Keystone assembler engine.
 # By Nguyen Anh Quynh, 2016
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8)
 
 project(kstool)
 

--- a/vendor/keystone/llvm/CMakeLists.txt
+++ b/vendor/keystone/llvm/CMakeLists.txt
@@ -1,6 +1,6 @@
 # See docs/CMake.html for instructions about how to build LLVM with CMake.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 2.8.7)
 
 set(LLVM_INSTALL_TOOLCHAIN_ONLY ON)
 
@@ -14,6 +14,11 @@ if(POLICY CMP0022)
 endif()
 
 if (POLICY CMP0051)
+  # CMake 3.1 and higher include generator expressions of the form
+  # $<TARGETLIB:obj> in the SOURCES property.  These need to be
+  # stripped everywhere that access the SOURCES property, so we just
+  # defer to the OLD behavior of not including generator expressions
+  # in the output for now.
   cmake_policy(SET CMP0051 NEW)
 endif()
 

--- a/vendor/keystone/llvm/include/llvm/ADT/STLExtras.h
+++ b/vendor/keystone/llvm/include/llvm/ADT/STLExtras.h
@@ -21,6 +21,7 @@
 #include <algorithm> // for std::all_of
 #include <cassert>
 #include <cstddef> // for std::size_t
+#include <cstdint> // for std::intptr_t
 #include <cstdlib> // for qsort
 #include <functional>
 #include <iterator>

--- a/vendor/keystone/llvm/include/llvm/MC/MCContext.h
+++ b/vendor/keystone/llvm/include/llvm/MC/MCContext.h
@@ -249,6 +249,7 @@ namespace llvm_ks {
     void setUseNamesOnTempLabels(bool Value) { UseNamesOnTempLabels = Value; }
 
     uint64_t getBaseAddress() { return BaseAddress; }
+    void setBaseAddress(uint64_t Addr) { BaseAddress = Addr; }
 
     /// \name Module Lifetime Management
     /// @{

--- a/vendor/keystone/llvm/keystone/ks.cpp
+++ b/vendor/keystone/llvm/keystone/ks.cpp
@@ -554,7 +554,9 @@ ks_err ks_close(ks_engine *ks)
 KEYSTONE_EXPORT
 ks_err ks_option(ks_engine *ks, ks_opt_type type, size_t value)
 {
-    ks->MAI->setRadix(16);
+    // Default to decimal immediates (NASM/Intel/GAS are all decimal by
+    // default). Hex-default is opt-in via the KS_OPT_SYNTAX_RADIX16 flag below.
+    ks->MAI->setRadix(10);
     switch(type) {
         case KS_OPT_SYNTAX:
             if (ks->arch != KS_ARCH_X86)
@@ -568,7 +570,10 @@ ks_err ks_option(ks_engine *ks, ks_opt_type type, size_t value)
                     ks->MAI->setRadix(16);
                 case KS_OPT_SYNTAX_NASM:
                 case KS_OPT_SYNTAX_INTEL:
-                    ks->syntax = (ks_opt_value)value;
+                    // Store the base syntax without the radix flag so that
+                    // syntax comparisons (e.g. == KS_OPT_SYNTAX_NASM) still hold
+                    // when RADIX16 is combined in.
+                    ks->syntax = (ks_opt_value)(value & ~KS_OPT_SYNTAX_RADIX16);
                     ks->MAI->setAssemblerDialect(1);
                     break;
                 case KS_OPT_SYNTAX_GAS | KS_OPT_SYNTAX_RADIX16:
@@ -576,7 +581,10 @@ ks_err ks_option(ks_engine *ks, ks_opt_type type, size_t value)
                     ks->MAI->setRadix(16);
                 case KS_OPT_SYNTAX_GAS:
                 case KS_OPT_SYNTAX_ATT:
-                    ks->syntax = (ks_opt_value)value;
+                    // Store the base syntax without the radix flag so that
+                    // syntax comparisons (e.g. == KS_OPT_SYNTAX_NASM) still hold
+                    // when RADIX16 is combined in.
+                    ks->syntax = (ks_opt_value)(value & ~KS_OPT_SYNTAX_RADIX16);
                     ks->MAI->setAssemblerDialect(0);
                     break;
             }

--- a/vendor/keystone/llvm/lib/MC/MCAsmInfo.cpp
+++ b/vendor/keystone/llvm/lib/MC/MCAsmInfo.cpp
@@ -25,6 +25,7 @@ using namespace llvm_ks;
 MCAsmInfo::MCAsmInfo() {
   PointerSize = 4;
   CalleeSaveStackSlotSize = 4;
+  Radix = 10; // decimal immediates by default
 
   IsLittleEndian = true;
   StackGrowsUp = false;

--- a/vendor/keystone/llvm/lib/MC/MCAssembler.cpp
+++ b/vendor/keystone/llvm/lib/MC/MCAssembler.cpp
@@ -207,8 +207,11 @@ bool MCAssembler::evaluateFixup(const MCAsmLayout &Layout,
             uint64_t imm;
             ks_sym_resolver resolver = (ks_sym_resolver)KsSymResolver;
             if (resolver(Sym.getName().str().c_str(), &imm)) {
-                // resolver handled this symbol
-                Value = imm;
+                // resolver handled this symbol. Add (not overwrite) so any
+                // constant already folded into the fixup is preserved -- e.g.
+                // the X86 emitter bakes the PC-relative -4 bias into the
+                // displacement, so a resolved 'call sym' must keep it.
+                Value += imm;
                 IsResolved = true;
             } else {
                 // resolver did not handle this symbol
@@ -323,6 +326,16 @@ uint64_t MCAssembler::computeFragmentSize(const MCAsmLayout &Layout,
         return 0;
       }
       TargetLocation += Val;
+    }
+    // Handle a subtracted symbol so that symbol-difference offsets work (this
+    // is how the NASM 'times N-($-$$) db x' fill is computed at layout time).
+    if (const MCSymbolRefExpr *B = Value.getSymB()) {
+      uint64_t Val;
+      if (!Layout.getSymbolOffset(B->getSymbol(), Val, valid)) {
+        valid = false;
+        return 0;
+      }
+      TargetLocation -= Val;
     }
     int64_t Size = TargetLocation - FragmentOffset;
     if (Size < 0 || Size >= 0x40000000) {

--- a/vendor/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
+++ b/vendor/keystone/llvm/lib/MC/MCParser/AsmLexer.cpp
@@ -320,6 +320,50 @@ AsmToken AsmLexer::LexDigit()
     return intToken(Result, Value);
   }
 
+  // NASM octal prefix: 0o[0-7]+ or 0q[0-7]+
+  if (*CurPtr == 'o' || *CurPtr == 'O' || *CurPtr == 'q' || *CurPtr == 'Q') {
+    ++CurPtr;
+    const char *NumStart = CurPtr;
+    while (CurPtr[0] >= '0' && CurPtr[0] <= '7')
+      ++CurPtr;
+
+    // Requires at least one octal digit.
+    if (CurPtr == NumStart)
+      return ReturnError(TokStart, "invalid octal number");
+
+    StringRef Result(TokStart, CurPtr - TokStart);
+
+    APInt Value(128, 0, true);
+    if (Result.substr(2).getAsInteger(8, Value))
+      return ReturnError(TokStart, "invalid octal number");
+
+    SkipIgnoredIntegerSuffix(CurPtr);
+
+    return intToken(Result, Value);
+  }
+
+  // NASM binary prefix: 0y[01]+ (alternative spelling of 0b)
+  if (*CurPtr == 'y' || *CurPtr == 'Y') {
+    ++CurPtr;
+    const char *NumStart = CurPtr;
+    while (CurPtr[0] == '0' || CurPtr[0] == '1')
+      ++CurPtr;
+
+    // Requires at least one binary digit.
+    if (CurPtr == NumStart)
+      return ReturnError(TokStart, "invalid binary number");
+
+    StringRef Result(TokStart, CurPtr - TokStart);
+
+    APInt Value(128, 0, true);
+    if (Result.substr(2).getAsInteger(2, Value))
+      return ReturnError(TokStart, "invalid binary number");
+
+    SkipIgnoredIntegerSuffix(CurPtr);
+
+    return intToken(Result, Value);
+  }
+
   if (*CurPtr == 'x' || *CurPtr == 'X') {
     ++CurPtr;
     const char *NumStart = CurPtr;
@@ -383,8 +427,17 @@ AsmToken AsmLexer::LexSingleQuote()
 
   CurChar = getNextChar();
 
-  if (CurChar != '\'')
-    return ReturnError(TokStart, "single quote way too long");
+  if (CurChar != '\'') {
+    // More than one character between the quotes. NASM treats single-quoted
+    // text as a string literal (no escape processing), equivalent to a
+    // double-quoted string. Scan to the closing quote and emit a String token.
+    while (CurChar != '\'') {
+      if (CurChar == EOF)
+        return ReturnError(TokStart, "unterminated single quote");
+      CurChar = getNextChar();
+    }
+    return AsmToken(AsmToken::String, StringRef(TokStart, CurPtr - TokStart));
+  }
 
   // The idea here being that 'c' is basically just an integral
   // constant.

--- a/vendor/keystone/llvm/lib/MC/MCParser/AsmParser.cpp
+++ b/vendor/keystone/llvm/lib/MC/MCParser/AsmParser.cpp
@@ -15,6 +15,7 @@
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/SmallString.h"
 #include "llvm/ADT/StringMap.h"
+#include "llvm/ADT/StringSwitch.h"
 #include "llvm/ADT/Twine.h"
 #include "llvm/MC/MCAsmInfo.h"
 #include "llvm/MC/MCContext.h"
@@ -387,6 +388,16 @@ private:
     DK_NASM_BITS,    // NASM directive 'bits'
     DK_NASM_DEFAULT, // NASM directive 'default'
     DK_NASM_USE32,   // NASM directive 'use32'
+    DK_NASM_RESB,    // NASM reserve: resb/resw/resd/resq/rest/reso/resy/resz
+    DK_NASM_TIMES,   // NASM 'times' prefix
+    DK_NASM_EQU,     // NASM 'equ'
+    DK_NASM_ALIGN,   // NASM 'align'
+    DK_NASM_DT,      // NASM 'dt' (10 bytes)
+    DK_NASM_DO,      // NASM 'do' (16 bytes)
+    DK_NASM_DY,      // NASM 'dy' (32 bytes)
+    DK_NASM_DZ,      // NASM 'dz' (64 bytes)
+    DK_NASM_ORG,     // NASM 'org'
+    DK_NASM_SECTION, // NASM 'section' / 'segment'
     DK_END
   };
 
@@ -518,6 +529,21 @@ private:
 
   // "bits" (Nasm)
   bool parseNasmDirectiveBits();
+
+  // "resb"/"resw"/"resd"/"resq"/... (Nasm) -- reserve uninitialized space
+  bool parseNasmDirectiveReserve(unsigned Size, unsigned int &KsError);
+
+  // "times" (Nasm) -- repeat the rest of the statement N times
+  bool parseNasmDirectiveTimes(SMLoc DirectiveLoc, unsigned int &KsError);
+
+  // "times <location-dependent count> db <const>" -- layout-time fill
+  bool parseNasmTimesFill(const MCExpr *CountExpr, unsigned int &KsError);
+
+  // "align" (Nasm)
+  bool parseNasmDirectiveAlign(unsigned int &KsError);
+
+  // "org" (Nasm) -- set the origin/base address
+  bool parseNasmDirectiveOrg(unsigned int &KsError);
 
   // "use32" (Nasm)
   bool parseNasmDirectiveUse32();
@@ -662,6 +688,12 @@ const AsmToken &AsmParser::Lex() {
     if (ParentIncludeLoc != SMLoc()) {
       jumpToLoc(ParentIncludeLoc);
       tok = &Lexer.Lex();   // qq
+    } else if (isInsideMacroInstantiation()) {
+      // End of a macro-like instantiation buffer that has no explicit
+      // terminator directive (e.g. NASM 'times', where '.endr' is not a
+      // recognized directive). Pop back to where we came from.
+      handleMacroExit();
+      tok = &Lexer.getTok();
     }
   }
 
@@ -867,6 +899,29 @@ bool AsmParser::parsePrimaryExprAux(const MCExpr *&Res, SMLoc &EndLoc, unsigned 
     Res = MCUnaryExpr::createLNot(Res, getContext());
     return false;
   case AsmToken::Dollar:
+    // NASM location counters: '$' (current address) and '$$' (start of the
+    // current section). In NASM syntax '$' references the PC; the global
+    // DollarIsPC flag is left untouched so AT&T '$'-immediates keep working.
+    if (FirstTokenKind == AsmToken::Dollar &&
+        (Lexer.getMAI().getDollarIsPC() || KsSyntax == KS_OPT_SYNTAX_NASM)) {
+      Lex(); // eat the first '$'
+      if (Lexer.is(AsmToken::Dollar)) {
+        // '$$' => start address of the current section (the base address).
+        Lex(); // eat the second '$'
+        Res = MCConstantExpr::create(getContext().getBaseAddress(),
+                                     getContext());
+        EndLoc = FirstTokenLoc;
+        return false;
+      }
+      // '$' => current PC. Emit a temporary label and refer to it.
+      MCSymbol *Sym = Ctx.createTempSymbol();
+      Out.EmitLabel(Sym);
+      Res = MCSymbolRefExpr::create(Sym, MCSymbolRefExpr::VK_None,
+                                    getContext());
+      EndLoc = FirstTokenLoc;
+      return false;
+    }
+    // fall through
   case AsmToken::At:
   case AsmToken::String:
   case AsmToken::Identifier: {
@@ -1583,6 +1638,18 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
 
   // FIXME: Recurse on local labels?
 
+  // NASM constant definition: "name equ expression". Here 'equ' shows up as
+  // an identifier token following the symbol name.
+  if (KsSyntax == KS_OPT_SYNTAX_NASM && !IDVal.empty() &&
+      Lexer.is(AsmToken::Identifier) && getTok().getIdentifier().lower() == "equ") {
+    Lex(); // consume 'equ'
+    if (parseAssignment(IDVal, /*allow_redef=*/true)) {
+      Info.KsError = KS_ERR_ASM_DIRECTIVE_EQU;
+      return true;
+    }
+    return false;
+  }
+
   // See what kind of statement we have.
   switch (Lexer.getKind()) {
   case AsmToken::Colon: {
@@ -1929,6 +1996,43 @@ bool AsmParser::parseStatement(ParseStatementInfo &Info,
       } else {
         return false;
       }
+    case DK_NASM_RESB: {
+      unsigned Unit = StringSwitch<unsigned>(IDVal.lower())
+                          .Case("resb", 1)
+                          .Case("resw", 2)
+                          .Case("resd", 4)
+                          .Case("resq", 8)
+                          .Case("rest", 10)
+                          .Case("reso", 16)
+                          .Case("resy", 32)
+                          .Case("resz", 64)
+                          .Default(1);
+      return parseNasmDirectiveReserve(Unit, Info.KsError);
+    }
+    case DK_NASM_TIMES:
+      return parseNasmDirectiveTimes(IDLoc, Info.KsError);
+    case DK_NASM_EQU:
+      // Bare 'equ' with no preceding label name is invalid.
+      Info.KsError = KS_ERR_ASM_DIRECTIVE_ID;
+      return true;
+    case DK_NASM_ALIGN:
+      return parseNasmDirectiveAlign(Info.KsError);
+    case DK_NASM_DT:
+      return parseDirectiveValue(10, Info.KsError);
+    case DK_NASM_DO:
+      return parseDirectiveValue(16, Info.KsError);
+    case DK_NASM_DY:
+      return parseDirectiveValue(32, Info.KsError);
+    case DK_NASM_DZ:
+      return parseDirectiveValue(64, Info.KsError);
+    case DK_NASM_ORG:
+      return parseNasmDirectiveOrg(Info.KsError);
+    case DK_NASM_SECTION:
+      // Keystone uses a single flat output stream (code and data are mixed in
+      // one section by design), so section/segment switches are accepted and
+      // output stays in source order. Consume the section name and attributes.
+      eatToEndOfStatement();
+      return false;
     }
 
     //return Error(IDLoc, "unknown directive");
@@ -2810,6 +2914,74 @@ bool AsmParser::parseDirectiveValue(unsigned Size, unsigned int &KsError)
     checkForValidSection();
 
     for (;;) {
+      // NASM allows string literals as operands of db/dw/dd/dq. The string
+      // bytes are laid out in order and zero-padded up to a multiple of the
+      // unit size (e.g. `dw "ABC"` => 41 42 43 00).
+      if (KsSyntax == KS_OPT_SYNTAX_NASM && getLexer().is(AsmToken::String)) {
+        bool valid;
+        StringRef Str = getTok().getStringContents(valid);
+        if (!valid) {
+          KsError = KS_ERR_ASM_DIRECTIVE_STR;
+          return true;
+        }
+        bool Error;
+        for (unsigned char C : Str)
+          getStreamer().EmitIntValue(C, 1, Error);
+        // Zero-pad to a whole number of units.
+        if (Size > 1 && (Str.size() % Size) != 0) {
+          for (size_t i = Str.size() % Size; i < Size; ++i)
+            getStreamer().EmitIntValue(0, 1, Error);
+        }
+        Lex(); // consume the string token
+
+        if (getLexer().is(AsmToken::EndOfStatement))
+          break;
+        if (getLexer().isNot(AsmToken::Comma)) {
+          KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+          return true;
+        }
+        Lex();
+        continue;
+      }
+
+      // NASM allows floating-point literals in dd/dq/dt, emitting the value in
+      // the matching IEEE/x87 format (dd => 32-bit single, dq => 64-bit double,
+      // dt => 80-bit extended). db/dw cannot hold a float.
+      if (KsSyntax == KS_OPT_SYNTAX_NASM && getLexer().is(AsmToken::Real)) {
+        if (Size != 4 && Size != 8 && Size != 10) {
+          KsError = KS_ERR_ASM_DIRECTIVE_FPOINT;
+          return true;
+        }
+        const fltSemantics &Sem = Size == 4 ? APFloat::IEEEsingle
+                                : Size == 8 ? APFloat::IEEEdouble
+                                            : APFloat::x87DoubleExtended;
+        APFloat F(Sem);
+        if (F.convertFromString(getTok().getString(),
+                                APFloat::rmNearestTiesToEven) ==
+            APFloat::opInvalidOp) {
+          KsError = KS_ERR_ASM_DIRECTIVE_FPOINT;
+          return true;
+        }
+        APInt Bits = F.bitcastToAPInt();
+        const uint64_t *Raw = Bits.getRawData();
+        unsigned NumBytes = Bits.getBitWidth() / 8;
+        bool Error;
+        for (unsigned i = 0; i < Size; ++i) {
+          uint8_t b = (i < NumBytes) ? (uint8_t)(Raw[i / 8] >> ((i % 8) * 8)) : 0;
+          getStreamer().EmitIntValue(b, 1, Error);
+        }
+        Lex(); // consume the real token
+
+        if (getLexer().is(AsmToken::EndOfStatement))
+          break;
+        if (getLexer().isNot(AsmToken::Comma)) {
+          KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+          return true;
+        }
+        Lex();
+        continue;
+      }
+
       const MCExpr *Value;
       SMLoc ExprLoc = getLexer().getLoc();
       if (parseExpression(Value)) {
@@ -2819,18 +2991,26 @@ bool AsmParser::parseDirectiveValue(unsigned Size, unsigned int &KsError)
 
       // Special case constant expressions to match code generator.
       if (const MCConstantExpr *MCE = dyn_cast<MCConstantExpr>(Value)) {
-        assert(Size <= 8 && "Invalid size");
         uint64_t IntValue = MCE->getValue();
-        if (!isUIntN(8 * Size, IntValue) && !isIntN(8 * Size, IntValue)) {
-            // return Error(ExprLoc, "literal value out of range for directive");
-            KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
-            return true;
-        }
         bool Error;
-        getStreamer().EmitIntValue(IntValue, Size, Error);
-        if (Error) {
-            KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
-            return true;
+        if (Size > 8) {
+          // Wide units (dt/do/dy/dz): emit the value in the low 8 bytes and
+          // zero-extend to the full width.
+          for (unsigned i = 0; i < Size; ++i) {
+            uint8_t b = (i < 8) ? (uint8_t)(IntValue >> (i * 8)) : 0;
+            getStreamer().EmitIntValue(b, 1, Error);
+          }
+        } else {
+          if (!isUIntN(8 * Size, IntValue) && !isIntN(8 * Size, IntValue)) {
+              // return Error(ExprLoc, "literal value out of range for directive");
+              KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+              return true;
+          }
+          getStreamer().EmitIntValue(IntValue, Size, Error);
+          if (Error) {
+              KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+              return true;
+          }
         }
       } else
         getStreamer().EmitValue(Value, Size, ExprLoc);
@@ -5326,6 +5506,258 @@ bool AsmParser::parseNasmDirectiveDefault()
   return true;
 }
 
+/// parseNasmDirectiveReserve
+/// ::= (resb | resw | resd | resq | rest | reso | resy | resz) count
+/// Reserves uninitialized space; in a flat binary this emits zero bytes.
+bool AsmParser::parseNasmDirectiveReserve(unsigned Size, unsigned int &KsError)
+{
+  checkForValidSection();
+
+  int64_t Count;
+  if (parseAbsoluteExpression(Count)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+    return true;
+  }
+
+  if (getLexer().isNot(AsmToken::EndOfStatement)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+    return true;
+  }
+  Lex();
+
+  if (Count < 0) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+
+  getStreamer().EmitFill((uint64_t)Count * Size, 0);
+  return false;
+}
+
+/// parseNasmDirectiveAlign
+/// ::= align boundary [, fill]
+/// where fill is an optional 'db <value>', 'nop', or bare value.
+bool AsmParser::parseNasmDirectiveAlign(unsigned int &KsError)
+{
+  checkForValidSection();
+
+  int64_t Alignment;
+  if (parseAbsoluteExpression(Alignment)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+    return true;
+  }
+  if (Alignment <= 0) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+
+  // NASM pads with single-byte nops (0x90) in a code context, matching its
+  // 'bin' output, unless an explicit fill value is supplied.
+  int64_t FillValue = 0x90;
+  if (getLexer().is(AsmToken::Comma)) {
+    Lex();
+    if (getLexer().is(AsmToken::Identifier)) {
+      StringRef Kw = getTok().getIdentifier().lower();
+      if (Kw == "nop") {
+        FillValue = 0x90;
+        Lex();
+      } else if (Kw == "db" || Kw == "dw" || Kw == "dd" || Kw == "dq") {
+        Lex(); // consume the data keyword, then read the fill value
+        if (parseAbsoluteExpression(FillValue)) {
+          KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+          return true;
+        }
+      } else if (parseAbsoluteExpression(FillValue)) {
+        KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+        return true;
+      }
+    } else if (parseAbsoluteExpression(FillValue)) {
+      KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+      return true;
+    }
+  }
+
+  if (getLexer().isNot(AsmToken::EndOfStatement)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+    return true;
+  }
+  Lex();
+
+  getStreamer().EmitValueToAlignment(Alignment, FillValue, 1, 0);
+  return false;
+}
+
+/// Returns true if the expression tree references any symbol/label (including
+/// the NASM '$' location counter). Defined labels fold to their parse-time
+/// offset during evaluation, so this structural check is the only reliable way
+/// to tell a true compile-time constant from a layout-dependent value.
+static bool exprReferencesSymbol(const MCExpr *E) {
+  switch (E->getKind()) {
+  case MCExpr::Constant:
+    return false;
+  case MCExpr::SymbolRef:
+    return true;
+  case MCExpr::Unary:
+    return exprReferencesSymbol(cast<MCUnaryExpr>(E)->getSubExpr());
+  case MCExpr::Binary: {
+    const MCBinaryExpr *BE = cast<MCBinaryExpr>(E);
+    return exprReferencesSymbol(BE->getLHS()) ||
+           exprReferencesSymbol(BE->getRHS());
+  }
+  case MCExpr::Target:
+    return true; // conservative
+  }
+  return true;
+}
+
+/// parseNasmDirectiveTimes
+/// ::= times count statement
+/// Repeats the rest of the statement 'count' times. Implemented by building a
+/// fresh source buffer holding the body repeated count times and lexing it.
+bool AsmParser::parseNasmDirectiveTimes(SMLoc DirectiveLoc, unsigned int &KsError)
+{
+  const char *CountStart = getTok().getLoc().getPointer();
+  const MCExpr *CountExpr;
+  if (parseExpression(CountExpr)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+    return true;
+  }
+  StringRef CountText(CountStart, getTok().getLoc().getPointer() - CountStart);
+
+  // A count that depends on the current location -- the NASM '$'/'$$' counters,
+  // as in 'times 510-($-$$) db 0' -- is not a compile-time constant (and
+  // parseExpression folds the embedded labels to a wrong parse-time offset).
+  // Such a count is handled by the location-dependent path below; it requires a
+  // single 'db <constant>' body, which becomes a layout-time fill to a computed
+  // offset. ('equ' constants fold to a plain constant and take the fast path.)
+  bool LocationDependent =
+      CountText.find('$') != StringRef::npos || exprReferencesSymbol(CountExpr);
+
+  if (LocationDependent)
+    return parseNasmTimesFill(CountExpr, KsError);
+
+  int64_t Count;
+  if (!CountExpr->evaluateAsAbsolute(Count)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+  if (Count < 0) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+
+  // Capture the remaining text of the statement as the body to repeat.
+  const char *BodyStart = getTok().getLoc().getPointer();
+  while (Lexer.isNot(AsmToken::EndOfStatement) && Lexer.isNot(AsmToken::Eof))
+    Lex();
+  const char *BodyEnd = getTok().getLoc().getPointer();
+  StringRef Body(BodyStart, BodyEnd - BodyStart);
+
+  if (Count == 0) {
+    // Nothing to emit; consume the end-of-statement and move on.
+    Lex();
+    return false;
+  }
+
+  SmallString<256> Buf;
+  raw_svector_ostream OS(Buf);
+  while (Count--)
+    OS << Body << "\n";
+
+  std::unique_ptr<MemoryBuffer> Instantiation =
+      MemoryBuffer::getMemBufferCopy(OS.str(), "<times>");
+
+  // Push an instantiation entry; the EOF of the new buffer returns us here.
+  MacroInstantiation *MI = new MacroInstantiation(
+      DirectiveLoc, CurBuffer, getTok().getLoc(), TheCondStack.size());
+  ActiveMacros.push_back(MI);
+
+  CurBuffer = SrcMgr.AddNewSourceBuffer(std::move(Instantiation), SMLoc());
+  Lexer.setBuffer(SrcMgr.getMemoryBuffer(CurBuffer)->getBuffer());
+  Lex();
+  return false;
+}
+
+/// parseNasmTimesFill -- handle 'times <count> db <const>' when the count is
+/// location-dependent (involves $/$$ or labels). Such a count is only knowable
+/// at layout time, so we emit a fill to a computed offset rather than repeating
+/// the body. With a 'db <fill>' body the fill is a single repeated byte, which
+/// the org fragment produces. The target section offset is
+///   <here> + count   ==   (anchor - $$) + count_expr
+/// where 'anchor' is a label at the current position; the count's own '$' and
+/// our anchor sit at the same place, so the symbol difference resolves to the
+/// intended constant offset at layout.
+bool AsmParser::parseNasmTimesFill(const MCExpr *CountExpr, unsigned int &KsError)
+{
+  // Only 'db <constant>' is representable here. A location-dependent count is
+  // turned into a layout-time fill to a computed offset, and the org fragment
+  // fills a single repeated byte. A wider unit (dw/dd/dq) would scale the
+  // count -- hence the '$' label inside it -- by the unit size, which a
+  // relocatable expression cannot represent; the forms people actually use
+  // (e.g. 'times (N-($-$$))/4 dd 0') additionally divide a label, which is not
+  // evaluable single-pass. Such fills genuinely require a multi-pass assembler.
+  if (!(getLexer().is(AsmToken::Identifier) &&
+        getTok().getIdentifier().lower() == "db")) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+  Lex(); // consume 'db'
+
+  const MCExpr *FillExpr;
+  if (parseExpression(FillExpr)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+    return true;
+  }
+  int64_t FillVal;
+  if (exprReferencesSymbol(FillExpr) || !FillExpr->evaluateAsAbsolute(FillVal) ||
+      (!isUIntN(8, FillVal) && !isIntN(8, FillVal))) {
+    KsError = KS_ERR_ASM_DIRECTIVE_VALUE_RANGE;
+    return true;
+  }
+  if (getLexer().isNot(AsmToken::EndOfStatement)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+    return true;
+  }
+  Lex();
+
+  // Anchor the current position and build the target-location expression
+  //   CountExpr + <here>
+  // which evaluates, at layout, to the location the fill must reach. The org
+  // fragment compares against a base-address-inclusive fragment offset, so the
+  // anchor's full address (not a section-relative offset) is used; the count's
+  // own '$' and our anchor sit at the same place, so any base/offset terms
+  // cancel (as a symbol difference) to the intended fill length.
+  MCSymbol *Anchor = getContext().createTempSymbol();
+  getStreamer().EmitLabel(Anchor);
+  const MCExpr *AnchorRef =
+      MCSymbolRefExpr::create(Anchor, MCSymbolRefExpr::VK_None, getContext());
+  const MCExpr *Offset =
+      MCBinaryExpr::createAdd(CountExpr, AnchorRef, getContext());
+  getStreamer().emitValueToOffset(Offset, (unsigned char)FillVal);
+  return false;
+}
+
+/// parseNasmDirectiveOrg
+/// ::= org address
+/// Sets the origin: labels and $/$$ are resolved relative to this address.
+/// Unlike a file offset, this does not emit any padding (matching NASM 'bin').
+bool AsmParser::parseNasmDirectiveOrg(unsigned int &KsError)
+{
+  int64_t Addr;
+  if (parseAbsoluteExpression(Addr)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_INVALID;
+    return true;
+  }
+  if (getLexer().isNot(AsmToken::EndOfStatement)) {
+    KsError = KS_ERR_ASM_DIRECTIVE_TOKEN;
+    return true;
+  }
+  Lex();
+
+  getContext().setBaseAddress((uint64_t)Addr);
+  return false;
+}
+
 /// parseDirectiveEndIf
 /// ::= .endif
 bool AsmParser::parseDirectiveEndIf(SMLoc DirectiveLoc)
@@ -5362,6 +5794,25 @@ void AsmParser::initializeDirectiveKindMap(int syntax)
         DirectiveKindMap["dw"] = DK_SHORT;
         DirectiveKindMap["dd"] = DK_INT;
         DirectiveKindMap["dq"] = DK_QUAD;
+        DirectiveKindMap["dt"] = DK_NASM_DT;
+        DirectiveKindMap["do"] = DK_NASM_DO;
+        DirectiveKindMap["dy"] = DK_NASM_DY;
+        DirectiveKindMap["dz"] = DK_NASM_DZ;
+        DirectiveKindMap["org"] = DK_NASM_ORG;
+        DirectiveKindMap["section"] = DK_NASM_SECTION;
+        DirectiveKindMap["segment"] = DK_NASM_SECTION;
+        DirectiveKindMap["extern"] = DK_EXTERN;
+        DirectiveKindMap["resb"] = DK_NASM_RESB;
+        DirectiveKindMap["resw"] = DK_NASM_RESB;
+        DirectiveKindMap["resd"] = DK_NASM_RESB;
+        DirectiveKindMap["resq"] = DK_NASM_RESB;
+        DirectiveKindMap["rest"] = DK_NASM_RESB;
+        DirectiveKindMap["reso"] = DK_NASM_RESB;
+        DirectiveKindMap["resy"] = DK_NASM_RESB;
+        DirectiveKindMap["resz"] = DK_NASM_RESB;
+        DirectiveKindMap["times"] = DK_NASM_TIMES;
+        DirectiveKindMap["equ"] = DK_NASM_EQU;
+        DirectiveKindMap["align"] = DK_NASM_ALIGN;
         DirectiveKindMap["use16"] = DK_CODE16;
         DirectiveKindMap["use32"] = DK_NASM_USE32;
         DirectiveKindMap["global"] = DK_GLOBAL;

--- a/vendor/keystone/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
+++ b/vendor/keystone/llvm/lib/Target/X86/AsmParser/X86AsmParser.cpp
@@ -69,6 +69,9 @@ private:
   // PUSH i8  --> PUSH32i8
   // PUSH word i8 --> PUSH16i8
   bool push32;
+  // PUSH word imm16 --> PUSHi16 (otherwise an imm16 that does not fit in i8
+  // matches the generic PUSHi32 and loses the 0x66 operand-size prefix).
+  bool push16;
   SMLoc consumeToken() {
     MCAsmParser &Parser = getParser();
     SMLoc Result = Parser.getTok().getLoc();
@@ -322,6 +325,9 @@ private:
     unsigned BaseReg, IndexReg, TmpReg, Scale;
     int64_t Imm;
     const MCExpr *Sym;
+    // A second, subtracted symbol so that symbol differences such as
+    // [eax + b - a] can be represented (the displacement becomes Sym - SymB).
+    const MCExpr *SymB;
     StringRef SymName;
     bool StopOnLBrac, AddImmPrefix, Rel, Abs;
     InfixCalculator IC;
@@ -330,13 +336,14 @@ private:
   public:
     IntelExprStateMachine(int64_t imm, bool stoponlbrac, bool addimmprefix, bool isrel=false) :
       State(IES_PLUS), PrevState(IES_ERROR), BaseReg(0), IndexReg(0), TmpReg(0),
-      Scale(1), Imm(imm), Sym(nullptr), StopOnLBrac(stoponlbrac),
+      Scale(1), Imm(imm), Sym(nullptr), SymB(nullptr), StopOnLBrac(stoponlbrac),
       AddImmPrefix(addimmprefix), Rel(isrel), Abs(false) { Info.clear(); }
 
     unsigned getBaseReg() { return (Rel && !Abs && BaseReg == 0 && IndexReg == 0) ? (unsigned)X86::RIP : BaseReg; }
     unsigned getIndexReg() { return IndexReg; }
     unsigned getScale() { return Scale; }
     const MCExpr *getSym() { return Sym; }
+    const MCExpr *getSymB() { return SymB; }
     StringRef getSymName() { return SymName; }
     int64_t getImm(unsigned int &KsError) { return Imm + IC.execute(KsError); }
     bool isValidEndState() {
@@ -447,7 +454,15 @@ private:
                 State = IES_ERROR;
                 break;
             }
-            IndexReg = TmpReg;
+            // The stack pointer (ESP/RSP) cannot be encoded as a SIB index.
+            // When it would land in the index slot with scale 1, swap it into
+            // the base slot, as NASM does (e.g. [rax+rsp] -> [rsp+rax]).
+            if (TmpReg == X86::ESP || TmpReg == X86::RSP) {
+                IndexReg = BaseReg;
+                BaseReg = TmpReg;
+            } else {
+                IndexReg = TmpReg;
+            }
             Scale = 1;
           }
         }
@@ -488,7 +503,15 @@ private:
                 State = IES_ERROR;
                 break;
             }
-            IndexReg = TmpReg;
+            // The stack pointer (ESP/RSP) cannot be encoded as a SIB index.
+            // When it would land in the index slot with scale 1, swap it into
+            // the base slot, as NASM does (e.g. [rax+rsp] -> [rsp+rax]).
+            if (TmpReg == X86::ESP || TmpReg == X86::RSP) {
+                IndexReg = BaseReg;
+                BaseReg = TmpReg;
+            } else {
+                IndexReg = TmpReg;
+            }
             Scale = 1;
           }
         }
@@ -554,6 +577,7 @@ private:
       PrevState = CurrState;
     }
     void onIdentifierExpr(const MCExpr *SymRef, StringRef SymRefName) {
+      IntelExprState CurrState = State;
       PrevState = State;
       switch (State) {
       default:
@@ -563,8 +587,19 @@ private:
       case IES_MINUS:
       case IES_NOT:
         State = IES_INTEGER;
-        Sym = SymRef;
-        SymName = SymRefName;
+        if (!Sym) {
+          Sym = SymRef;
+          SymName = SymRefName;
+        } else if (CurrState == IES_MINUS && !SymB) {
+          // A subtracted second symbol: the displacement is a symbol
+          // difference (e.g. [eax + b - a]).
+          SymB = SymRef;
+        } else {
+          // More than two symbols, or two added symbols -- unrepresentable
+          // here; keep the previous (single-symbol) behaviour.
+          Sym = SymRef;
+          SymName = SymRefName;
+        }
         IC.pushOperand(IC_IMM);
         break;
       }
@@ -599,6 +634,15 @@ private:
           if(Scale != 1 && Scale != 2 && Scale != 4 && Scale != 8) {
             ErrMsg = "scale factor in address must be 1, 2, 4 or 8";
             return true;
+          }
+          // The stack pointer (ESP/RSP) cannot be a SIB index. If it was given
+          // an explicit scale of 1 (e.g. [rbx+rsp*1]), swap it into the base
+          // slot as NASM does.
+          if ((IndexReg == X86::ESP || IndexReg == X86::RSP) && Scale == 1 &&
+              BaseReg) {
+            unsigned Tmp = BaseReg;
+            BaseReg = IndexReg;
+            IndexReg = Tmp;
           }
           // Get the scale and replace the 'Register * Scale' with '0'.
           IC.popOperator();
@@ -691,7 +735,15 @@ private:
                 State = IES_ERROR;
                 break;
             }
-            IndexReg = TmpReg;
+            // The stack pointer (ESP/RSP) cannot be encoded as a SIB index.
+            // When it would land in the index slot with scale 1, swap it into
+            // the base slot, as NASM does (e.g. [rax+rsp] -> [rsp+rax]).
+            if (TmpReg == X86::ESP || TmpReg == X86::RSP) {
+                IndexReg = BaseReg;
+                BaseReg = TmpReg;
+            } else {
+                IndexReg = TmpReg;
+            }
             Scale = 1;
           }
         }
@@ -1540,6 +1592,25 @@ X86AsmParser::ParseIntelBracExpression(unsigned SegReg, SMLoc Start,
     return ErrorOperand(BracLoc, "Expected '[' token!");
   Parser.Lex(); // Eat '['
 
+  // NASM/Intel write a segment override inside the brackets: [seg:disp]
+  // (e.g. [es:0x10], [fs:eax]). Detect a leading 'segreg :' here -- the
+  // 'seg:[...]' form is handled earlier by ParseIntelSegmentOverride.
+  if (SegReg == 0 && getLexer().is(AsmToken::Identifier) &&
+      getLexer().peekTok().is(AsmToken::Colon)) {
+    unsigned SegRegNo = 0;
+    SMLoc SegStart, SegEnd;
+    unsigned int SegErr;
+    if (!ParseRegister(SegRegNo, SegStart, SegEnd, SegErr) &&
+        (SegRegNo == X86::ES || SegRegNo == X86::CS || SegRegNo == X86::SS ||
+         SegRegNo == X86::DS || SegRegNo == X86::FS || SegRegNo == X86::GS)) {
+      SegReg = SegRegNo;
+      Parser.Lex(); // Eat ':'
+    } else {
+      KsError = KS_ERR_ASM_INVALIDOPERAND;
+      return nullptr;
+    }
+  }
+
   SMLoc StartInBrac = Tok.getLoc();
   bool IsRel;
   switch(SegReg) {
@@ -1565,6 +1636,10 @@ X86AsmParser::ParseIntelBracExpression(unsigned SegReg, SMLoc Start,
   if (const MCExpr *Sym = SM.getSym()) {
     // A symbolic displacement.
     Disp = Sym;
+    // A symbol difference, e.g. [eax + b - a], resolves to the distance
+    // between the two labels at layout time.
+    if (const MCExpr *SymB = SM.getSymB())
+      Disp = MCBinaryExpr::createSub(Disp, SymB, getContext());
     if (isParsingInlineAsm())
       RewriteIntelBracExpression(*InstInfo->AsmRewrites, SM.getSymName(),
                                  ImmDisp, SM.getImm(KsError), BracLoc, StartInBrac,
@@ -2035,6 +2110,8 @@ std::unique_ptr<X86Operand> X86AsmParser::ParseIntelOperand(std::string Mnem, un
       if (Mnem == "push") {
           if (Size == 0)
               push32 = true;
+          else if (Size == 16)
+              push16 = true;
       }
 
       const MCExpr *ImmExpr = MCConstantExpr::create(Imm, getContext());
@@ -2609,6 +2686,7 @@ bool X86AsmParser::ParseInstruction(ParseInstructionInfo &Info, StringRef Name,
     Name == "rex64" || Name == "data16";
 
   push32 = false;
+  push16 = false;
 
   // This does the actual operand parsing.  Don't parse any more if we have a
   // prefix juxtaposed with an operation like "lock incl 4(%rax)", because we
@@ -3216,8 +3294,54 @@ bool X86AsmParser::MatchAndEmitIntelInstruction(SMLoc IDLoc, unsigned &Opcode,
       ErrorInfoMissingFeature = ErrorInfo;
   }
 
-  if (push32 && Inst.getOpcode() == X86::PUSH16i8)
-      Inst.setOpcode(X86::PUSH32i8);
+  // 'push word <imm>' forces a 16-bit operand.
+  if (push16 && Inst.getOpcode() == X86::PUSHi32)
+      Inst.setOpcode(X86::PUSHi16);
+  // A bare 'push <imm>' (push32 == "no explicit size") follows the CPU mode:
+  // 32-bit in 32/64-bit mode (the matcher's imm8 default is the 16-bit form,
+  // so bump it up), 16-bit in 16-bit mode (bump the imm16/32 default down).
+  if (push32) {
+    if (is16BitMode()) {
+      if (Inst.getOpcode() == X86::PUSHi32)
+          Inst.setOpcode(X86::PUSHi16);
+    } else {
+      if (Inst.getOpcode() == X86::PUSH16i8)
+          Inst.setOpcode(X86::PUSH32i8);
+    }
+  }
+
+  // The Intel-syntax mnemonic alias table (unlike AT&T's) lacks the
+  // mode-dependent operand-size suffixing for several no-/immediate-operand
+  // instructions (ret/iret/pushf/popf/push imm/call imm), so they match one
+  // fixed variant and then pick up a spurious 0x66 operand-size prefix in the
+  // other CPU mode. Re-select the mode-appropriate variant here (AT&T already
+  // resolves these via the alias table, so only do it for Intel/NASM syntax).
+  if (isParsingIntelSyntax()) {
+    if (is16BitMode()) {
+      switch (Inst.getOpcode()) {
+      case X86::RETL:   Inst.setOpcode(X86::RETW);   break;
+      case X86::RETIL:  Inst.setOpcode(X86::RETIW);  break;
+      case X86::LRETL:  Inst.setOpcode(X86::LRETW);  break;
+      case X86::LRETIL: Inst.setOpcode(X86::LRETIW); break;
+      case X86::CALLpcrel32: Inst.setOpcode(X86::CALLpcrel16); break;
+      default: break;
+      }
+    } else if (is32BitMode()) {
+      switch (Inst.getOpcode()) {
+      case X86::IRET16:  Inst.setOpcode(X86::IRET32);  break;
+      case X86::PUSHF16: Inst.setOpcode(X86::PUSHF32); break;
+      case X86::POPF16:  Inst.setOpcode(X86::POPF32);  break;
+      default: break;
+      }
+    } else if (is64BitMode()) {
+      switch (Inst.getOpcode()) {
+      case X86::IRET16:  Inst.setOpcode(X86::IRET64);  break;
+      case X86::PUSHF16: Inst.setOpcode(X86::PUSHF64); break;
+      case X86::POPF16:  Inst.setOpcode(X86::POPF64);  break;
+      default: break;
+      }
+    }
+  }
 
   // Restore the size of the unsized memory operand if we modified it.
   if (UnsizedMemOp)

--- a/vendor/keystone/suite/regress/README
+++ b/vendor/keystone/suite/regress/README
@@ -4,3 +4,9 @@ Run ./regress.py to execute all the tests.
 
 Take test1.py as an example when you create a new regression.
 Please fill in the Github issue number & Author in your regression.
+
+x86_emulate_directives.py additionally runs the assembled output in the Unicorn
+CPU emulator (an end-to-end check that directive/boot code actually executes).
+It is skipped automatically unless Unicorn is installed:
+
+    pip install unicorn

--- a/vendor/keystone/suite/regress/arm_sym_resolver.py
+++ b/vendor/keystone/suite/regress/arm_sym_resolver.py
@@ -12,11 +12,12 @@ import regress
 class TestARM(regress.RegressTest):
     def runTest(self):
         def sym_resolver(symbol, value):
-            if symbol == "symBackward":
+            # The symbol name arrives as bytes from the C callback.
+            if symbol == b"symBackward":
                 value[0] = 0x0
                 return True
 
-            if symbol == "symForward":
+            if symbol == b"symForward":
                 value[0] = 0x20
                 return True
 

--- a/vendor/keystone/suite/regress/arm_sym_resolver_thumb.py
+++ b/vendor/keystone/suite/regress/arm_sym_resolver_thumb.py
@@ -12,11 +12,12 @@ import regress
 class TestARM(regress.RegressTest):
     def runTest(self):
         def sym_resolver(symbol, value):
-            if symbol == "symBackward":
+            # The symbol name arrives as bytes from the C callback.
+            if symbol == b"symBackward":
                 value[0] = 0x0
                 return True
 
-            if symbol == "symForward":
+            if symbol == b"symForward":
                 value[0] = 0x20
                 return True
 

--- a/vendor/keystone/suite/regress/x64_sym_resolver.py
+++ b/vendor/keystone/suite/regress/x64_sym_resolver.py
@@ -13,11 +13,11 @@ class TestX86(regress.RegressTest):
     def runTest(self):
         def sym_resolver(symbol, value):
             # is this the missing symbol we want to handle?
-            if symbol == "ZwQueryInformationProcess":
-                # put value of this symbol in @value
-                value = 0x7FF98A050840
+            if symbol == b"ZwQueryInformationProcess":
+                # put value of this symbol in @value (write through the pointer)
+                value[0] = 0x7FF98A050840
                 # we handled this symbol, so return true
-                print 'sym_resolver called!'
+                print('sym_resolver called!')
                 return True
  
             # we did not handle this symbol, so return false

--- a/vendor/keystone/suite/regress/x86_call0.py
+++ b/vendor/keystone/suite/regress/x86_call0.py
@@ -16,8 +16,10 @@ class TestX86(regress.RegressTest):
         ks = Ks(KS_ARCH_X86, KS_MODE_32)
         # Assemble to get back insn encoding & statement count
         encoding, count = ks.asm(b"call 0")
-        # Assert the result
-        self.assertEqual(encoding, [ 0xE8, 0x00, 0x00, 0x00, 0x00 ])
+        # 'call 0' targets absolute address 0; with the call at address 0 the
+        # PC-relative displacement is 0 - 5 = -5. This matches NASM
+        # ('call 0' -> e8 fb ff ff ff).
+        self.assertEqual(encoding, [ 0xE8, 0xFB, 0xFF, 0xFF, 0xFF ])
 
 if __name__ == '__main__':
     regress.main()

--- a/vendor/keystone/suite/regress/x86_call_ptr_sym.py
+++ b/vendor/keystone/suite/regress/x86_call_ptr_sym.py
@@ -12,7 +12,8 @@ import regress
 
 def sym_resolver(symbol, value):
     if symbol == b'GetPhoneBuildString':
-        value = 0x41b000
+        # value is a pointer; write through it so the C side sees the result.
+        value[0] = 0x41b000
         return True
     return False
 

--- a/vendor/keystone/suite/regress/x86_emulate_directives.py
+++ b/vendor/keystone/suite/regress/x86_emulate_directives.py
@@ -1,0 +1,221 @@
+#!/usr/bin/python
+
+# End-to-end test: assemble directive-heavy NASM code with Keystone and *run*
+# the resulting bytes in the Unicorn CPU emulator, asserting on the runtime
+# state. This validates that data directives (db/dw/dd/equ/times/$/$$), labels,
+# org, segment overrides and a full boot sequence produce code that actually
+# executes correctly -- not merely bytes that look right.
+#
+# Unicorn is an optional dependency; the whole module is skipped when it is not
+# installed, so it never breaks the core regression run.
+#
+# Author: keystone-engine fork
+
+import unittest
+
+from keystone import *
+
+import regress
+
+try:
+    from unicorn import *
+    from unicorn.x86_const import *
+    _HAVE_UNICORN = True
+except ImportError:
+    _HAVE_UNICORN = False
+
+
+CODE = 0x100000      # where flat 32-bit test code is loaded
+STACK = 0x308000     # stack pointer (middle of the stack map)
+
+
+def _hlt_stops(uc):
+    # Stop the emulator the moment a HLT (0xF4) is about to execute, so each
+    # snippet can end with `hlt` instead of running off into garbage.
+    def hook(uc, addr, size, user):
+        if uc.mem_read(addr, 1)[0] == 0xF4:
+            uc.emu_stop()
+    uc.hook_add(UC_HOOK_CODE, hook)
+
+
+@unittest.skipUnless(_HAVE_UNICORN, "unicorn not installed")
+class TestEmulateDirectives32(regress.RegressTest):
+    """Assemble 32-bit NASM directive code and execute it."""
+
+    def _run(self, asm, regs=None):
+        ks = Ks(KS_ARCH_X86, KS_MODE_32)
+        ks.syntax = KS_OPT_SYNTAX_NASM
+        code, _ = ks.asm(asm.encode(), CODE)
+        code = bytes(code)
+
+        uc = Uc(UC_ARCH_X86, UC_MODE_32)
+        uc.mem_map(CODE, 0x100000)
+        uc.mem_map(0x300000, 0x10000)
+        uc.mem_map(0x0, 0x10000)        # low scratch for segment-override stores
+        uc.mem_write(CODE, code)
+        uc.reg_write(UC_X86_REG_ESP, STACK)
+        uc.reg_write(UC_X86_REG_EBP, STACK)
+        if regs:
+            for r, v in regs.items():
+                uc.reg_write(r, v)
+        _hlt_stops(uc)
+        uc.emu_start(CODE, CODE + len(code), count=100000)
+        return uc
+
+    def runTest(self):
+        # dd data reference: load a 32-bit value defined with `dd`.
+        uc = self._run("mov eax, [val]\nhlt\nval: dd 0xdeadbeef")
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 0xdeadbeef)
+
+        # db string with an indexed load.
+        uc = self._run('movzx eax, byte [msg+2]\nhlt\nmsg: db "ABCDEF"')
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), ord('C'))
+
+        # equ constant.
+        uc = self._run("LEN equ 7\nmov eax, LEN\nhlt")
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 7)
+
+        # `$ - label` length computation.
+        uc = self._run('jmp s\nmsg: db "hello"\nlen equ $-msg\ns:\nmov eax, len\nhlt')
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 5)
+
+        # times-padding must be skipped by a jump over it.
+        uc = self._run("jmp code\ntimes 16 db 0x90\ncode:\nmov eax, 0x1234\nhlt")
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 0x1234)
+
+        # dd array summed in a loop (data directive + label + indexed access).
+        uc = self._run("""
+            xor eax, eax
+            xor esi, esi
+            mov ecx, 4
+        sum:
+            add eax, [arr+esi*4]
+            inc esi
+            dec ecx
+            jnz sum
+            hlt
+        arr: dd 10, 20, 30, 40
+        """)
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 100)
+
+        # Segment-override stores/loads ([es:...] / [ds:...]) round-trip.
+        uc = self._run("""
+            mov ax, 0
+            mov es, ax
+            mov dword [es:0x9000], 0xCAFEB00B
+            mov eax, [es:0x9000]
+            mov ebx, [ds:0x9000]
+            hlt
+        """)
+        self.assertEqual(uc.reg_read(UC_X86_REG_EAX), 0xCAFEB00B)
+        self.assertEqual(uc.reg_read(UC_X86_REG_EBX), 0xCAFEB00B)
+
+
+@unittest.skipUnless(_HAVE_UNICORN, "unicorn not installed")
+class TestBootSector(regress.RegressTest):
+    """Assemble a real 512-byte boot sector and run it in 16-bit real mode."""
+
+    def runTest(self):
+        ks = Ks(KS_ARCH_X86, KS_MODE_16)
+        ks.syntax = KS_OPT_SYNTAX_NASM
+        src = """
+            org 0x7c00
+            start:
+                mov ax, 0x1234
+                mov bx, msg
+                add ax, [val]
+                hlt
+            msg: db "OK"
+            val: dw 0x1111
+            times 510-($-$$) db 0
+            dw 0xaa55
+        """
+        code, _ = ks.asm(src.encode(), 0x7c00)
+        code = bytes(code)
+
+        # The hallmark of a boot sector: exactly 512 bytes, 0x55AA signature.
+        self.assertEqual(len(code), 512)
+        self.assertEqual(code[510:512], b"\x55\xaa")
+
+        uc = Uc(UC_ARCH_X86, UC_MODE_16)
+        uc.mem_map(0x0, 0x10000)
+        uc.mem_write(0x7c00, code)
+        uc.reg_write(UC_X86_REG_CS, 0)
+        uc.reg_write(UC_X86_REG_SS, 0)
+        uc.reg_write(UC_X86_REG_SP, 0x7000)
+        _hlt_stops(uc)
+        uc.emu_start(0x7c00, 0x7c00 + len(code), count=10000)
+
+        # ax = 0x1234 + [val]=0x1111 = 0x2345 ; bx points at the org-relative msg.
+        self.assertEqual(uc.reg_read(UC_X86_REG_AX), 0x2345)
+        self.assertTrue(0x7c00 <= uc.reg_read(UC_X86_REG_BX) < 0x7e00)
+
+
+@unittest.skipUnless(_HAVE_UNICORN, "unicorn not installed")
+class TestProtectedModeBoot(regress.RegressTest):
+    """Boot sector that builds a GDT from data directives and switches the CPU
+    into 32-bit protected mode, then runs 32-bit code."""
+
+    def runTest(self):
+        ks = Ks(KS_ARCH_X86, KS_MODE_16)
+        ks.syntax = KS_OPT_SYNTAX_NASM
+        src = r"""
+            [bits 16]
+            org 0x7c00
+            start:
+                cli
+                xor ax, ax
+                mov ds, ax
+                lgdt [gdt_desc]
+                mov eax, cr0
+                or eax, 1
+                mov cr0, eax
+                jmp 0x08:pm_entry
+
+            [bits 32]
+            pm_entry:
+                mov ax, 0x10
+                mov ds, ax
+                mov dword [0x9000], 0x504D4F4B   ; marker only 32-bit code writes
+                mov eax, 0x1000
+                mov ebx, 0x0337
+                add eax, ebx
+                mov dword [0x9004], eax          ; 0x1337
+                hlt
+
+            align 8
+            gdt_start:
+                dq 0x0000000000000000            ; null
+            gdt_code:
+                dw 0xFFFF, 0x0000
+                db 0x00, 0x9A, 0xCF, 0x00        ; base=0 limit=4G 32-bit code
+            gdt_data:
+                dw 0xFFFF, 0x0000
+                db 0x00, 0x92, 0xCF, 0x00        ; base=0 limit=4G 32-bit data
+            gdt_end:
+            gdt_desc:
+                dw gdt_end - gdt_start - 1        ; limit (label difference)
+                dd gdt_start                      ; base  (label reference)
+
+            times 510-($-$$) db 0
+            dw 0xAA55
+        """
+        code, _ = ks.asm(src.encode(), 0x7c00)
+        code = bytes(code)
+        self.assertEqual(len(code), 512)
+        self.assertEqual(code[510:512], b"\x55\xaa")
+
+        uc = Uc(UC_ARCH_X86, UC_MODE_16)
+        uc.mem_map(0x0, 0x100000)
+        uc.mem_write(0x7c00, code)
+        _hlt_stops(uc)
+        uc.emu_start(0x7c00, 0, count=200000)
+
+        # PE bit set, and the 32-bit markers prove PM code actually ran.
+        self.assertEqual(uc.reg_read(UC_X86_REG_CR0) & 1, 1)
+        self.assertEqual(int.from_bytes(uc.mem_read(0x9000, 4), "little"), 0x504D4F4B)
+        self.assertEqual(int.from_bytes(uc.mem_read(0x9004, 4), "little"), 0x1337)
+
+
+if __name__ == '__main__':
+    regress.main()

--- a/vendor/keystone/suite/regress/x86_issue293.py
+++ b/vendor/keystone/suite/regress/x86_issue293.py
@@ -17,7 +17,7 @@ class TestX86(regress.RegressTest):
         try:
             # An exception should be raised from the jnz exit:; being bad
             encoding, count = ks.asm(b"jnz exit:; add eax, ebx; exit: ret")
-        except Exception, e:
+        except Exception as e:
             return
         raise Exception
 

--- a/vendor/local/usr/local/include/keystone/keystone.h
+++ b/vendor/local/usr/local/include/keystone/keystone.h
@@ -16,11 +16,19 @@ extern "C" {
 #ifdef _MSC_VER     // MSVC compiler
 #pragma warning(disable:4201)
 #pragma warning(disable:4100)
+#ifndef KEYSTONE_STATIC
 #define KEYSTONE_EXPORT __declspec(dllexport)
+#else
+#define KEYSTONE_EXPORT
+#endif
 #else
 #ifdef __GNUC__
 #include <stdbool.h>
+#ifndef KEYSTONE_STATIC
 #define KEYSTONE_EXPORT __attribute__((visibility("default")))
+#else
+#define KEYSTONE_EXPORT
+#endif
 #else
 #define KEYSTONE_EXPORT
 #endif
@@ -56,6 +64,7 @@ typedef enum ks_arch {
     KS_ARCH_SYSTEMZ,    // SystemZ architecture (S390X)
     KS_ARCH_HEXAGON,    // Hexagon architecture
     KS_ARCH_EVM,        // Ethereum Virtual Machine architecture
+    KS_ARCH_RISCV,      // RISC-V architecture
     KS_ARCH_MAX,
 } ks_arch;
 
@@ -81,6 +90,9 @@ typedef enum ks_mode {
     KS_MODE_PPC32 = 1 << 2,       // 32-bit mode
     KS_MODE_PPC64 = 1 << 3,       // 64-bit mode
     KS_MODE_QPX = 1 << 4,         // Quad Processing eXtensions mode
+        //riscv
+    KS_MODE_RISCV32 = 1 << 2,     // 32-bit mode
+    KS_MODE_RISCV64 = 1 << 3,     // 64-bit mode
     // sparc
     KS_MODE_SPARC32 = 1 << 2,     // 32-bit mode
     KS_MODE_SPARC64 = 1 << 3,     // 64-bit mode
@@ -181,6 +193,7 @@ typedef enum ks_opt_value {
 #include "hexagon.h"
 #include "mips.h"
 #include "ppc.h"
+#include "riscv.h"
 #include "sparc.h"
 #include "systemz.h"
 #include "x86.h"

--- a/vendor/local/usr/local/include/keystone/riscv.h
+++ b/vendor/local/usr/local/include/keystone/riscv.h
@@ -1,0 +1,24 @@
+/* Keystone Assembler Engine */
+/* By Nguyen Anh Quynh, 2016 */
+/* Added by Mark Juvan, 2023*/
+#ifndef KEYSTONE_RISCV_H
+#define KEYSTONE_RISCV_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "keystone.h"
+
+typedef enum ks_err_asm_riscv {
+    KS_ERR_ASM_RISCV_INVALIDOPERAND = KS_ERR_ASM_ARCH,
+    KS_ERR_ASM_RISCV_MISSINGFEATURE,
+    KS_ERR_ASM_RISCV_MNEMONICFAIL,
+} ks_err_asm_riscv;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/vendor/local/usr/local/lib/pkgconfig/keystone.pc
+++ b/vendor/local/usr/local/lib/pkgconfig/keystone.pc
@@ -1,7 +1,8 @@
 Name: keystone
 Description: Keystone assembler engine
 Version: 0.9
-libdir=/usr/local/lib
-includedir=/usr/local/include
+prefix=${pcfiledir}/../..
+libdir=${prefix}/lib
+includedir=${prefix}/include
 Libs: -L${libdir} -lkeystone
 Cflags: -I${includedir}


### PR DESCRIPTION
## Summary
- replace the vendored/local Keystone build with HACKE-RC/keystone
- switch the default demo to NASM syntax and fix startup assembly syntax
- improve executor stepping/end detection and breakpoint toggling

## Verification
- cmake --build src/build -j22
- ctest --test-dir src/build --output-on-failure
- git diff --check