### PR TITLE
Fix fileSaveTask to write target file without full re-open

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -101,6 +101,7 @@ set(SRC_INTEGRATION
     ${APP_DIR}/integration/debugBackend.cpp
     ${APP_DIR}/integration/debugState.cpp
     ${APP_DIR}/integration/elfLoader.cpp
+    ${APP_DIR}/integration/linuxProcess.cpp
     ${APP_DIR}/integration/interpreter/interpreter.cpp
     ${APP_DIR}/integration/interpreter/registers.cpp
     ${APP_DIR}/integration/interpreter/vm.cpp

--- a/src/app/actions/actions.cpp
+++ b/src/app/actions/actions.cpp
@@ -27,6 +27,9 @@ int pendingHighlightLine = -1;
 bool pendingRemoteUiSync = false;
 bool pendingRemoteRefreshTarget = false;
 bool pendingRemoteResetCodeMemoryBase = false;
+bool pendingLocalElfUiSync = false;
+uint64_t pendingLocalElfPc = 0;
+bool pendingLocalElfForce = false;
 std::optional<uint64_t> remoteDisassemblyBaseAddress{};
 uint64_t remoteResumeGeneration = 0;
 
@@ -252,12 +255,22 @@ void requestRemoteUiSync(const bool refreshTarget, const bool resetCodeMemoryBas
     pendingRemoteResetCodeMemoryBase = pendingRemoteResetCodeMemoryBase || resetCodeMemoryBase;
 }
 
+void requestLocalElfUiSync(const uint64_t currentPc, const bool force) {
+    std::lock_guard<std::mutex> lock(uiUpdateMutex);
+    pendingLocalElfUiSync = true;
+    pendingLocalElfPc = currentPc;
+    pendingLocalElfForce = pendingLocalElfForce || force;
+}
+
 void processUIUpdates() {
     bool applyHighlight = false;
     int highlightLine = -1;
     bool applyRemoteSync = false;
     bool refreshTarget = false;
     bool resetCodeMemoryBase = false;
+    bool applyLocalElfSync = false;
+    uint64_t localElfPc = 0;
+    bool forceLocalElfSync = false;
 
     {
         std::lock_guard<std::mutex> lock(uiUpdateMutex);
@@ -275,14 +288,32 @@ void processUIUpdates() {
             pendingRemoteRefreshTarget = false;
             pendingRemoteResetCodeMemoryBase = false;
         }
+
+        if (pendingLocalElfUiSync) {
+            applyLocalElfSync = true;
+            localElfPc = pendingLocalElfPc;
+            forceLocalElfSync = pendingLocalElfForce;
+            pendingLocalElfUiSync = false;
+            pendingLocalElfPc = 0;
+            pendingLocalElfForce = false;
+        }
     }
 
     if (applyRemoteSync) {
         syncRemoteUiState(refreshTarget, resetCodeMemoryBase);
     }
 
+    if (applyLocalElfSync && isCodeRunning) {
+        requestLocalElfUiSync(localElfPc, forceLocalElfSync);
+    } else if (applyLocalElfSync) {
+        syncLocalElfDisassemblyView(localElfPc, forceLocalElfSync);
+    }
+
     if (applyHighlight) {
         editor->HighlightDebugCurrentLine(highlightLine);
+        if (highlightLine >= 0) {
+            editor->SetCursorPosition(highlightLine, 0);
+        }
     }
 }
 
@@ -540,6 +571,13 @@ void restartDebugging(){
             }
             return;
         }
+        if (localElfBinaryLoaded()) {
+            if (!reloadElfBinaryForDebug()) {
+                consoleWriteThreadSafe("elf >> restart failed\n");
+            }
+            LOG_INFO("ELF debugging restarted.");
+            return;
+        }
         resetState();
         fileRunTask(false);
         LOG_INFO("Debugging restarted successfully.");
@@ -646,7 +684,12 @@ void debugStopAction(){
         remote_gdb::disconnectRemoteDebugSession();
     }
     debugModeEnabled = false;
-    resetState();
+    if (localElfBinaryLoaded()) {
+        clearLocalElfBinary();
+        resetState(false);
+    } else {
+        resetState();
+    }
     LOG_INFO("Debugging stopped successfully.");
 }
 
@@ -919,6 +962,17 @@ void runActions(){
                 } else {
                     consoleWriteThreadSafe("remote >> run/continue failed\n");
                 }
+                return;
+            }
+
+            if (localElfBinaryLoaded()) {
+                skipBreakpoints = true;
+                if (reloadElfBinaryForDebug()) {
+                    stepCode(0);
+                } else {
+                    consoleWriteThreadSafe("elf >> run failed\n");
+                }
+                skipBreakpoints = false;
                 return;
             }
 

--- a/src/app/actions/actions.hpp
+++ b/src/app/actions/actions.hpp
@@ -1,6 +1,7 @@
 #ifndef ZATHURA_ACTIONS_HPP
 #define ZATHURA_ACTIONS_HPP
 #include "../app.hpp"
+#include <cstdint>
 #include <optional>
 extern std::mutex debugActionsMutex;
 extern std::optional<uint64_t> remoteDisassemblyBaseAddress;
@@ -19,5 +20,6 @@ void safeHighlightLine(int lineNo);
 void processUIUpdates();
 void executeInBackground(const std::function<void()>& func);
 void requestRemoteUiSync(bool refreshTarget = false, bool resetCodeMemoryBase = false);
+void requestLocalElfUiSync(uint64_t currentPc, bool force = false);
 
 #endif //ZATHURA_ACTIONS_HPP

--- a/src/app/integration/elfLoader.cpp
+++ b/src/app/integration/elfLoader.cpp
@@ -3,6 +3,7 @@
 #include "debugState.hpp"
 #include "gdb/gdbRemote.hpp"
 #include "interpreter/interpreter.hpp"
+#include "linuxProcess.hpp"
 
 #include "../app.hpp"
 
@@ -17,10 +18,15 @@
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
+#include <iterator>
+#include <limits>
 #include <map>
 #include <mutex>
 #include <optional>
+#include <set>
 #include <sstream>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 extern void instructionHook(void* userData, uint64_t address);
@@ -30,6 +36,26 @@ extern int handleSyscalls(void* data, uint64_t syscall_nr, const SyscallArgs* ar
 namespace {
 
 constexpr uint64_t kPageSize = 0x1000;
+constexpr uint64_t kDefaultPieBase = 0x555555554000ULL;
+constexpr uint64_t kInterpreterBase = 0x7ffff7dd0000ULL;
+constexpr size_t kLocalDisassemblyInstructionCount = 96;
+
+std::string loadedElfPath;
+std::map<uint64_t, std::string> gLocalElfSymbols;
+
+struct ElfLoadResult {
+    uint64_t initialPc = 0;
+    uint64_t programEntry = 0;
+    uint64_t loadBias = 0;
+    uint64_t programHeaders = 0;
+    uint64_t programHeaderEntrySize = 0;
+    uint64_t programHeaderCount = 0;
+    uint64_t minAddress = std::numeric_limits<uint64_t>::max();
+    uint64_t maxAddress = 0;
+    uint64_t brkStart = 0;
+    uint64_t interpreterBase = 0;
+    std::string interpreterPath;
+};
 
 uint64_t pageFloor(const uint64_t value) {
     return value & ~(kPageSize - 1);
@@ -76,6 +102,15 @@ bool readWholeFile(const std::string& path, std::vector<uint8_t>& bytes) {
     return input.good();
 }
 
+bool hasElfMagic(const std::vector<uint8_t>& file) {
+#ifndef _WIN32
+    return file.size() >= EI_NIDENT && std::memcmp(file.data(), ELFMAG, SELFMAG) == 0;
+#else
+    (void)file;
+    return false;
+#endif
+}
+
 bool rangeInFile(const uint64_t offset, const uint64_t size, const size_t fileSize) {
     return offset <= fileSize && size <= fileSize - offset;
 }
@@ -98,6 +133,11 @@ bool mapSegment(const std::vector<uint8_t>& file,
     if (icicle_mem_map(icicle, mapStart, mapSize, ExecuteReadWrite) != 0) {
         consoleWriteThreadSafe("elf >> failed to map segment at " + formatAddress(mapStart) + "\n");
         return false;
+    }
+
+    std::vector<uint8_t> zeroPage(static_cast<size_t>(kPageSize), 0);
+    for (uint64_t page = mapStart; page < mapStart + mapSize; page += kPageSize) {
+        icicle_mem_write(icicle, page, zeroPage.data(), zeroPage.size());
     }
 
     if (fileSize > 0 &&
@@ -125,121 +165,437 @@ std::optional<std::vector<uint8_t>> readEntryBytes(const uint64_t entry) {
     return std::nullopt;
 }
 
-void buildEntryDisassemblyView(const uint64_t entry) {
-    const auto bytes = readEntryBytes(entry);
+void mergeLocalElfSymbols(const std::string& path, const uint64_t loadBias) {
+    const auto symbols = remote_gdb::loadElfSymbols(path);
+    for (const auto& [address, name] : symbols.addrToName) {
+        if (!name.empty()) {
+            gLocalElfSymbols[loadBias + address] = name;
+        }
+    }
+}
+
+void rebuildLocalElfSymbols(const ElfLoadResult& image) {
+    gLocalElfSymbols.clear();
+    mergeLocalElfSymbols(loadedElfPath, image.loadBias);
+    if (!image.interpreterPath.empty()) {
+        mergeLocalElfSymbols(image.interpreterPath, image.interpreterBase);
+    }
+}
+
+std::string generatedLabelForAddress(const uint64_t address) {
+    std::ostringstream out;
+    out << "loc_" << std::hex << address;
+    return out.str();
+}
+
+std::string exactLabelForAddress(const uint64_t address) {
+    const auto symbol = gLocalElfSymbols.find(address);
+    if (symbol != gLocalElfSymbols.end()) {
+        return symbol->second;
+    }
+    return generatedLabelForAddress(address);
+}
+
+std::string lineAddressLabelForAddress(const uint64_t address) {
+    const auto symbol = gLocalElfSymbols.find(address);
+    if (symbol != gLocalElfSymbols.end()) {
+        return symbol->second;
+    }
+
+    const auto nextSymbol = gLocalElfSymbols.upper_bound(address);
+    if (nextSymbol != gLocalElfSymbols.begin()) {
+        const auto previousSymbol = std::prev(nextSymbol);
+        const auto offset = address - previousSymbol->first;
+        if (offset > 0 && offset < 0x1000) {
+            std::ostringstream out;
+            out << previousSymbol->second << "+0x" << std::hex << offset;
+            return out.str();
+        }
+    }
+
+    return formatAddress(address);
+}
+
+std::optional<uint64_t> extractBranchTarget(const cs_insn& instruction) {
+    if (instruction.detail == nullptr) {
+        return std::nullopt;
+    }
+
+    for (uint8_t groupIndex = 0; groupIndex < instruction.detail->groups_count; ++groupIndex) {
+        const auto group = instruction.detail->groups[groupIndex];
+        if (group != CS_GRP_JUMP && group != CS_GRP_CALL) {
+            continue;
+        }
+
+        const auto* detail = instruction.detail;
+        switch (codeInformation.archIC) {
+            case IC_ARCH_X86_64:
+                for (uint8_t operandIndex = 0; operandIndex < detail->x86.op_count; ++operandIndex) {
+                    if (detail->x86.operands[operandIndex].type == X86_OP_IMM) {
+                        return static_cast<uint64_t>(detail->x86.operands[operandIndex].imm);
+                    }
+                }
+                break;
+            case IC_ARCH_AARCH64:
+                for (uint8_t operandIndex = 0; operandIndex < detail->arm64.op_count; ++operandIndex) {
+                    if (detail->arm64.operands[operandIndex].type == ARM64_OP_IMM) {
+                        return static_cast<uint64_t>(detail->arm64.operands[operandIndex].imm);
+                    }
+                }
+                break;
+            case IC_ARCH_ARM:
+            case IC_ARCH_THUMBV7M:
+                for (uint8_t operandIndex = 0; operandIndex < detail->arm.op_count; ++operandIndex) {
+                    if (detail->arm.operands[operandIndex].type == ARM_OP_IMM) {
+                        return static_cast<uint64_t>(detail->arm.operands[operandIndex].imm);
+                    }
+                }
+                break;
+            default:
+                break;
+        }
+        break;
+    }
+
+    return std::nullopt;
+}
+
+std::string operandTextWithLabel(const cs_insn& instruction,
+                                 const std::map<uint64_t, std::string>& labelsByAddress) {
+    std::string operands = instruction.op_str;
+    const auto target = extractBranchTarget(instruction);
+    if (!target.has_value()) {
+        return operands;
+    }
+
+    std::optional<std::string> label;
+    if (const auto visibleLabel = labelsByAddress.find(*target); visibleLabel != labelsByAddress.end()) {
+        label = visibleLabel->second;
+    } else if (const auto symbol = gLocalElfSymbols.find(*target); symbol != gLocalElfSymbols.end()) {
+        label = symbol->second;
+    }
+
+    if (!label.has_value()) {
+        return operands;
+    }
+
+    const auto rawAddress = formatAddress(*target);
+    const auto addressPos = operands.find(rawAddress);
+    if (addressPos != std::string::npos) {
+        operands.replace(addressPos, rawAddress.size(), *label);
+        return operands;
+    }
+
+    return *label;
+}
+
+void rebuildLocalBreakpointHighlights() {
+    breakpointLines.clear();
+    editor->HighlightBreakpoints(-1, true);
+
+    for (const auto address : breakpointAddresses) {
+        const auto it = addressLineNoMap.find(address);
+        if (it == addressLineNoMap.end() || it->second == 0) {
+            continue;
+        }
+
+        breakpointLines.push_back(it->second);
+        editor->HighlightBreakpoints(static_cast<int>(it->second - 1));
+    }
+}
+
+bool buildLocalDisassemblyView(const uint64_t startAddress, const uint64_t currentAddress) {
+    const auto bytes = readEntryBytes(startAddress);
     if (!bytes.has_value() || bytes->empty()) {
-        return;
+        return false;
     }
 
     csh handle{};
     if (cs_open(codeInformation.archCS, codeInformation.modeCS, &handle) != CS_ERR_OK) {
-        return;
+        return false;
     }
+    cs_option(handle, CS_OPT_DETAIL, CS_OPT_ON);
 
     cs_insn* instructions = nullptr;
-    const auto count = cs_disasm(handle, bytes->data(), bytes->size(), entry, 96, &instructions);
+    const auto count = cs_disasm(handle, bytes->data(), bytes->size(), startAddress,
+                                 kLocalDisassemblyInstructionCount, &instructions);
     if (count == 0 || instructions == nullptr) {
         cs_close(&handle);
-        return;
+        return false;
+    }
+
+    std::unordered_set<uint64_t> visibleInstructionAddresses;
+    for (size_t i = 0; i < count; ++i) {
+        visibleInstructionAddresses.insert(instructions[i].address);
+    }
+
+    std::set<uint64_t> labelTargets;
+    for (size_t i = 0; i < count; ++i) {
+        const auto address = instructions[i].address;
+        if (gLocalElfSymbols.contains(address) || address == startAddress || address == currentAddress) {
+            labelTargets.insert(address);
+        }
+        if (auto target = extractBranchTarget(instructions[i]); target.has_value() &&
+            visibleInstructionAddresses.contains(*target)) {
+            labelTargets.insert(*target);
+        }
+    }
+
+    std::map<uint64_t, std::string> labelsByAddress;
+    std::unordered_set<std::string> usedLabelNames;
+    for (const auto address : labelTargets) {
+        if (!visibleInstructionAddresses.contains(address)) {
+            continue;
+        }
+
+        std::string label = exactLabelForAddress(address);
+        if (usedLabelNames.contains(label)) {
+            label += "_" + generatedLabelForAddress(address);
+        }
+        usedLabelNames.insert(label);
+        labelsByAddress[address] = label;
     }
 
     std::ostringstream text;
     std::map<int, std::string> lineAddressLabels;
     std::map<int, std::string> lineOffsetLabels;
-    const auto& symbols = remote_gdb::remoteLoadedSymbols().addrToName;
+    std::unordered_map<uint64_t, uint64_t> nextAddressLineNoMap;
+    std::map<std::string, int> nextLabelLineNoMap;
+    std::vector<std::string> nextLabels;
+    std::vector<uint64_t> nextEmptyLineNumbers;
+    int currentLine = -1;
+    uint64_t displayLine = 1;
+    bool firstLine = true;
 
-    addressLineNoMap.clear();
-    labelLineNoMapInternal.clear();
-    labels.clear();
+    auto appendLine = [&](const std::string& line) {
+        if (!firstLine) {
+            text << '\n';
+        }
+        text << line;
+        firstLine = false;
+    };
 
     for (size_t i = 0; i < count; ++i) {
         const auto address = instructions[i].address;
-        const auto line = static_cast<uint64_t>(i + 1);
-        addressLineNoMap[address] = line;
-
-        auto symbol = symbols.find(address);
-        if (symbol != symbols.end()) {
-            lineAddressLabels[static_cast<int>(i)] = symbol->second;
-            labelLineNoMapInternal[symbol->second] = static_cast<int>(line);
-            labels.push_back(symbol->second);
-        } else {
-            lineAddressLabels[static_cast<int>(i)] = formatAddress(address);
+        if (const auto label = labelsByAddress.find(address); label != labelsByAddress.end()) {
+            if (!firstLine) {
+                appendLine("");
+                nextEmptyLineNumbers.push_back(displayLine);
+                ++displayLine;
+            }
+            const auto lineIndex = static_cast<int>(displayLine - 1);
+            appendLine(label->second + ":");
+            lineAddressLabels[lineIndex] = formatAddress(address);
+            nextLabelLineNoMap[label->second] = static_cast<int>(displayLine);
+            nextLabels.push_back(label->second);
+            ++displayLine;
         }
+
+        const auto line = displayLine;
+        const auto lineIndex = static_cast<int>(line - 1);
+        nextAddressLineNoMap[address] = line;
+        if (address == currentAddress) {
+            currentLine = lineIndex;
+        }
+
+        lineAddressLabels[lineIndex] = lineAddressLabelForAddress(address);
 
         std::ostringstream offset;
-        offset << "+0x" << std::hex << (address - entry);
-        lineOffsetLabels[static_cast<int>(i)] = offset.str();
+        offset << "+0x" << std::hex << (address - startAddress);
+        lineOffsetLabels[lineIndex] = offset.str();
 
-        text << instructions[i].mnemonic;
-        if (instructions[i].op_str[0] != '\0') {
-            text << ' ' << instructions[i].op_str;
+        std::string lineText = instructions[i].mnemonic;
+        const auto operands = operandTextWithLabel(instructions[i], labelsByAddress);
+        if (!operands.empty()) {
+            lineText += ' ';
+            lineText += operands;
         }
-        if ((i + 1) < count) {
-            text << '\n';
-        }
+        appendLine(lineText);
+        ++displayLine;
     }
 
-    lastInstructionLineNo = static_cast<uint64_t>(count);
-    showRemoteDisassemblyInEditor(text.str(), 0, lineOffsetLabels, lineAddressLabels);
+    addressLineNoMap = std::move(nextAddressLineNoMap);
+    labelLineNoMapInternal = std::move(nextLabelLineNoMap);
+    labels = std::move(nextLabels);
+    emptyLineNumbers = std::move(nextEmptyLineNumbers);
+    lastInstructionLineNo = displayLine > 1 ? displayLine - 1 : 0;
+    showRemoteDisassemblyInEditor(text.str(), currentLine >= 0 ? currentLine : 0,
+                                  lineOffsetLabels, lineAddressLabels);
+    rebuildLocalBreakpointHighlights();
 
     cs_free(instructions, count);
     cs_close(&handle);
+
+    if (currentLine >= 0) {
+        safeHighlightLine(currentLine);
+    }
+    return currentLine >= 0;
 }
 
 #ifndef _WIN32
-bool loadElf64(const std::vector<uint8_t>& file, uint64_t& entry) {
+std::optional<std::string> readInterpreterPath(const std::vector<uint8_t>& file,
+                                               const uint64_t offset,
+                                               const uint64_t size) {
+    if (size == 0 || !rangeInFile(offset, size, file.size())) {
+        return std::nullopt;
+    }
+
+    std::string path(reinterpret_cast<const char*>(file.data() + offset), static_cast<size_t>(size));
+    if (!path.empty() && path.back() == '\0') {
+        path.pop_back();
+    }
+    return path.empty() ? std::nullopt : std::optional<std::string>(path);
+}
+
+std::optional<uint64_t> programHeadersAddress(const std::vector<uint8_t>& file,
+                                              const Elf64_Ehdr* header,
+                                              const Elf64_Phdr* phdrs,
+                                              const uint64_t loadBias) {
+    for (uint16_t i = 0; i < header->e_phnum; ++i) {
+        if (phdrs[i].p_type == PT_PHDR) {
+            return loadBias + phdrs[i].p_vaddr;
+        }
+    }
+
+    for (uint16_t i = 0; i < header->e_phnum; ++i) {
+        if (phdrs[i].p_type != PT_LOAD) {
+            continue;
+        }
+        if (header->e_phoff >= phdrs[i].p_offset &&
+            header->e_phoff < phdrs[i].p_offset + phdrs[i].p_filesz) {
+            return loadBias + phdrs[i].p_vaddr + (header->e_phoff - phdrs[i].p_offset);
+        }
+    }
+
+    if (rangeInFile(header->e_phoff, static_cast<uint64_t>(header->e_phnum) * header->e_phentsize, file.size())) {
+        return loadBias + header->e_phoff;
+    }
+    return std::nullopt;
+}
+
+std::optional<ElfLoadResult> loadElf64Image(const std::vector<uint8_t>& file,
+                                            const std::string& path,
+                                            const std::optional<uint64_t> requestedBase) {
     if (file.size() < sizeof(Elf64_Ehdr)) {
-        return false;
+        return std::nullopt;
     }
 
     const auto* header = reinterpret_cast<const Elf64_Ehdr*>(file.data());
-    if (header->e_phentsize != sizeof(Elf64_Phdr) ||
+    if (header->e_ident[EI_DATA] != ELFDATA2LSB ||
+        header->e_ident[EI_VERSION] != EV_CURRENT ||
+        header->e_machine != EM_X86_64 ||
+        (header->e_type != ET_EXEC && header->e_type != ET_DYN) ||
+        header->e_phentsize != sizeof(Elf64_Phdr) ||
         !rangeInFile(header->e_phoff, static_cast<uint64_t>(header->e_phnum) * header->e_phentsize, file.size())) {
-        return false;
+        consoleWriteThreadSafe("elf >> unsupported ELF64 image: " + path + "\n");
+        return std::nullopt;
     }
 
     const auto* phdrs = reinterpret_cast<const Elf64_Phdr*>(file.data() + header->e_phoff);
+    uint64_t minVaddr = std::numeric_limits<uint64_t>::max();
+    uint64_t maxVaddr = 0;
     for (uint16_t i = 0; i < header->e_phnum; ++i) {
         if (phdrs[i].p_type != PT_LOAD) {
             continue;
         }
-        if (!mapSegment(file, phdrs[i].p_vaddr, phdrs[i].p_offset,
+        minVaddr = std::min(minVaddr, pageFloor(phdrs[i].p_vaddr));
+        maxVaddr = std::max(maxVaddr, pageCeil(phdrs[i].p_vaddr + phdrs[i].p_memsz));
+    }
+
+    if (minVaddr == std::numeric_limits<uint64_t>::max()) {
+        consoleWriteThreadSafe("elf >> ELF has no loadable segments: " + path + "\n");
+        return std::nullopt;
+    }
+
+    const uint64_t loadBias = header->e_type == ET_DYN
+        ? pageFloor(requestedBase.value_or(kDefaultPieBase)) - minVaddr
+        : 0;
+
+    ElfLoadResult result;
+    result.loadBias = loadBias;
+    result.initialPc = loadBias + header->e_entry;
+    result.programEntry = result.initialPc;
+    result.programHeaderEntrySize = header->e_phentsize;
+    result.programHeaderCount = header->e_phnum;
+    result.minAddress = loadBias + minVaddr;
+    result.maxAddress = loadBias + maxVaddr;
+    result.brkStart = pageCeil(result.maxAddress);
+
+    for (uint16_t i = 0; i < header->e_phnum; ++i) {
+        if (phdrs[i].p_type == PT_INTERP) {
+            if (auto interpreter = readInterpreterPath(file, phdrs[i].p_offset, phdrs[i].p_filesz)) {
+                result.interpreterPath = *interpreter;
+            }
+            continue;
+        }
+
+        if (phdrs[i].p_type != PT_LOAD) {
+            continue;
+        }
+        if (!mapSegment(file, loadBias + phdrs[i].p_vaddr, phdrs[i].p_offset,
                         phdrs[i].p_filesz, phdrs[i].p_memsz, phdrs[i].p_flags)) {
-            return false;
+            consoleWriteThreadSafe("elf >> failed to map segment from " + path + "\n");
+            return std::nullopt;
         }
     }
 
-    entry = header->e_entry;
-    return entry != 0;
+    if (auto phdrAddress = programHeadersAddress(file, header, phdrs, loadBias)) {
+        result.programHeaders = *phdrAddress;
+    } else {
+        consoleWriteThreadSafe("elf >> failed to resolve program header address for " + path + "\n");
+        return std::nullopt;
+    }
+
+    return result.initialPc != 0 ? std::optional<ElfLoadResult>(result) : std::nullopt;
 }
 
-bool loadElf32(const std::vector<uint8_t>& file, uint64_t& entry) {
-    if (file.size() < sizeof(Elf32_Ehdr)) {
-        return false;
+bool setX86_64ModeForElf() {
+    codeInformation.archIC = IC_ARCH_X86_64;
+    codeInformation.archKS = KS_ARCH_X86;
+    codeInformation.archCS = CS_ARCH_X86;
+    codeInformation.mode = UC_MODE_64;
+    codeInformation.modeKS = KS_MODE_64;
+    codeInformation.modeCS = CS_MODE_64;
+    codeInformation.syntax = KS_OPT_SYNTAX_NASM;
+    codeInformation.archStr = "x86_64";
+    return initArch();
+}
+
+std::optional<ElfLoadResult> loadLinuxElfImage(const std::vector<uint8_t>& mainFile,
+                                               const std::string& path) {
+    auto mainImage = loadElf64Image(mainFile, path, std::nullopt);
+    if (!mainImage.has_value()) {
+        return std::nullopt;
     }
 
-    const auto* header = reinterpret_cast<const Elf32_Ehdr*>(file.data());
-    if (header->e_phentsize != sizeof(Elf32_Phdr) ||
-        !rangeInFile(header->e_phoff, static_cast<uint64_t>(header->e_phnum) * header->e_phentsize, file.size())) {
-        return false;
-    }
-
-    const auto* phdrs = reinterpret_cast<const Elf32_Phdr*>(file.data() + header->e_phoff);
-    for (uint16_t i = 0; i < header->e_phnum; ++i) {
-        if (phdrs[i].p_type != PT_LOAD) {
-            continue;
+    ElfLoadResult result = *mainImage;
+    if (!mainImage->interpreterPath.empty()) {
+        std::vector<uint8_t> interpreterFile;
+        if (!readWholeFile(mainImage->interpreterPath, interpreterFile) || !hasElfMagic(interpreterFile)) {
+            consoleWriteThreadSafe("elf >> failed to read ELF interpreter " + mainImage->interpreterPath + "\n");
+            return std::nullopt;
         }
-        if (!mapSegment(file, phdrs[i].p_vaddr, phdrs[i].p_offset,
-                        phdrs[i].p_filesz, phdrs[i].p_memsz, phdrs[i].p_flags)) {
-            return false;
+
+        auto interpreter = loadElf64Image(interpreterFile, mainImage->interpreterPath, kInterpreterBase);
+        if (!interpreter.has_value()) {
+            return std::nullopt;
         }
+
+        result.initialPc = interpreter->initialPc;
+        result.interpreterPath = mainImage->interpreterPath;
+        result.interpreterBase = interpreter->loadBias;
+        result.brkStart = mainImage->brkStart;
     }
 
-    entry = header->e_entry;
-    return entry != 0;
+    return result;
 }
 #endif
 
+}
+
+bool isElfBinaryFile(const std::string& path) {
+    std::vector<uint8_t> file;
+    return readWholeFile(path, file) && hasElfMagic(file);
 }
 
 bool loadElfBinaryForDebug(const std::string& path) {
@@ -256,38 +612,69 @@ bool loadElfBinaryForDebug(const std::string& path) {
     return false;
 #else
     std::vector<uint8_t> file;
-    if (!readWholeFile(path, file) || file.size() < EI_NIDENT ||
-        std::memcmp(file.data(), ELFMAG, SELFMAG) != 0) {
+    if (!readWholeFile(path, file) || !hasElfMagic(file)) {
         consoleWriteThreadSafe("elf >> not an ELF file: " + path + "\n");
         return false;
     }
 
-    resetState(false);
-    if (!createStack(icicle)) {
+    if (!setX86_64ModeForElf()) {
+        consoleWriteThreadSafe("elf >> failed to initialize x86_64 mode\n");
         return false;
     }
 
-    uint64_t entry = 0;
+    clearLinuxProcess();
+    loadedElfPath.clear();
+    resetState(false);
+    if (icicle == nullptr) {
+        icicle = initIC();
+    }
+    if (icicle == nullptr) {
+        consoleWriteThreadSafe("elf >> failed to initialize emulator\n");
+        return false;
+    }
+    initRegistersToDefinedVals();
+
     const auto elfClass = file[EI_CLASS];
-    bool loaded = false;
+    std::optional<ElfLoadResult> loadedImage;
     if (elfClass == ELFCLASS64) {
-        loaded = loadElf64(file, entry);
+        loadedImage = loadLinuxElfImage(file, path);
     } else if (elfClass == ELFCLASS32) {
-        loaded = loadElf32(file, entry);
+        consoleWriteThreadSafe("elf >> ELF32 Linux execution is not supported yet; use an x86_64 ELF\n");
     }
 
-    if (!loaded) {
+    if (!loadedImage.has_value()) {
         consoleWriteThreadSafe("elf >> failed to map loadable segments from " + path + "\n");
         return false;
     }
 
     selectedFile = path;
-    ENTRY_POINT_ADDRESS = entry;
-    MEMORY_EDITOR_BASE = pageFloor(entry);
-    icicle_set_pc(icicle, entry);
+    loadedElfPath = path;
+    ENTRY_POINT_ADDRESS = loadedImage->initialPc;
+    MEMORY_EDITOR_BASE = pageFloor(loadedImage->programEntry);
+    codeExecutableEndAddress = 0;
+    icicle_set_pc(icicle, loadedImage->initialPc);
+
+    LinuxProcessImage processImage;
+    processImage.path = path;
+    processImage.interpreterPath = loadedImage->interpreterPath;
+    processImage.initialPc = loadedImage->initialPc;
+    processImage.programEntry = loadedImage->programEntry;
+    processImage.programHeaders = loadedImage->programHeaders;
+    processImage.programHeaderEntrySize = loadedImage->programHeaderEntrySize;
+    processImage.programHeaderCount = loadedImage->programHeaderCount;
+    processImage.interpreterBase = loadedImage->interpreterBase;
+    processImage.loadBias = loadedImage->loadBias;
+    processImage.brkStart = loadedImage->brkStart;
+    configureLinuxProcess(processImage);
+    if (!setupLinuxProcessStack(icicle)) {
+        clearLinuxProcess();
+        loadedElfPath.clear();
+        return false;
+    }
 
     remote_gdb::remoteLoadSymbolFile(path);
-    buildEntryDisassemblyView(entry);
+    rebuildLocalElfSymbols(*loadedImage);
+    syncLocalElfDisassemblyView(loadedImage->initialPc, true);
 
     icicle_add_execution_hook(icicle, instructionHook, nullptr);
     icicle_add_mem_write_hook(icicle, stackWriteHook, nullptr, STACK_ADDRESS, STACK_ADDRESS + STACK_SIZE);
@@ -303,8 +690,44 @@ bool loadElfBinaryForDebug(const std::string& path) {
     debugModeEnabled = true;
     codeHasRun = true;
     updateStack = true;
+    if (snapshot == nullptr) {
+        snapshot = saveICSnapshot(icicle);
+    }
     updateRegs();
-    consoleWriteThreadSafe("elf >> loaded " + path + " at entry " + formatAddress(entry) + "\n");
+    consoleWriteThreadSafe("elf >> loaded " + path + " at entry " + formatAddress(loadedImage->programEntry) + "\n");
+    if (!loadedImage->interpreterPath.empty()) {
+        consoleWriteThreadSafe("elf >> using interpreter " + loadedImage->interpreterPath +
+                               " at " + formatAddress(loadedImage->initialPc) + "\n");
+    }
     return true;
 #endif
+}
+
+bool reloadElfBinaryForDebug() {
+    const auto path = loadedElfPath;
+    return !path.empty() && loadElfBinaryForDebug(path);
+}
+
+bool localElfBinaryLoaded() {
+    return !loadedElfPath.empty();
+}
+
+bool syncLocalElfDisassemblyView(const uint64_t currentPc, const bool force) {
+    if (loadedElfPath.empty()) {
+        return false;
+    }
+
+    const auto lineIt = addressLineNoMap.find(currentPc);
+    if (!force && lineIt != addressLineNoMap.end() && lineIt->second > 0) {
+        safeHighlightLine(static_cast<int>(lineIt->second - 1));
+        return true;
+    }
+
+    return buildLocalDisassemblyView(currentPc, currentPc);
+}
+
+void clearLocalElfBinary() {
+    loadedElfPath.clear();
+    gLocalElfSymbols.clear();
+    clearLinuxProcess();
 }

--- a/src/app/integration/elfLoader.hpp
+++ b/src/app/integration/elfLoader.hpp
@@ -1,5 +1,11 @@
 #pragma once
 
+#include <cstdint>
 #include <string>
 
+bool isElfBinaryFile(const std::string& path);
 bool loadElfBinaryForDebug(const std::string& path);
+bool reloadElfBinaryForDebug();
+bool localElfBinaryLoaded();
+bool syncLocalElfDisassemblyView(uint64_t currentPc, bool force = false);
+void clearLocalElfBinary();

--- a/src/app/integration/interpreter/execution.cpp
+++ b/src/app/integration/interpreter/execution.cpp
@@ -1,5 +1,7 @@
 #include "interpreter.hpp"
 #include "../debugState.hpp"
+#include "../elfLoader.hpp"
+#include "../linuxProcess.hpp"
 #include <capstone/capstone.h>
 #include <algorithm>
 
@@ -8,9 +10,15 @@ namespace {
 int sourceLineIndexForAddress(const uint64_t address)
 {
     const auto lineIt = addressLineNoMap.find(address);
-    return lineIt != addressLineNoMap.end() && lineIt->second > 0
-        ? static_cast<int>(lineIt->second - 1)
-        : -1;
+    if (lineIt != addressLineNoMap.end() && lineIt->second > 0) {
+        return static_cast<int>(lineIt->second - 1);
+    }
+
+    if (localElfBinaryLoaded()) {
+        requestLocalElfUiSync(address);
+    }
+
+    return -1;
 }
 
 int fallbackLastSourceLineIndex()
@@ -29,12 +37,14 @@ bool currentInstructionIsCall(const uint64_t address, uint64_t& fallthroughAddre
     fallthroughAddress = 0;
 
     const auto endAddress = codeEndAddress();
-    if (icicle == nullptr || endAddress == 0 || address >= endAddress)
+    if (icicle == nullptr || (endAddress != 0 && address >= endAddress))
     {
         return false;
     }
 
-    const auto maxRead = static_cast<size_t>(std::min<uint64_t>(16, endAddress - address));
+    const auto maxRead = static_cast<size_t>(endAddress != 0
+        ? std::min<uint64_t>(16, endAddress - address)
+        : 16);
     size_t outSize = 0;
     unsigned char* bytes = icicle_mem_read(icicle, address, maxRead, &outSize);
     if (bytes == nullptr || outSize == 0)
@@ -132,6 +142,11 @@ int getCurrentLine(){
 
 int handleSyscalls(void* data, uint64_t syscall_nr, const SyscallArgs* args)
 {
+    if (linuxProcessActive())
+    {
+        return handleLinuxProcessSyscall(data, syscall_nr, args);
+    }
+
     if (args != nullptr)
     {
         if (syscall_nr == 1)
@@ -290,6 +305,14 @@ bool checkStatusUpdateState(const size_t& instructionCount, RunStatus status, co
     if (lineIndex >= 0)
         safeHighlightLine(lineIndex);
 
+    if (linuxProcessExited())
+    {
+        executionComplete = true;
+        stoppedAtBreakpoint = false;
+        consoleWriteThreadSafe("linux >> exited with status " + std::to_string(linuxProcessExitCode()) + "\n");
+        return true;
+    }
+
     if (isAtCodeEnd(ip))
     {
         icicle_remove_breakpoint(icicle, ip);
@@ -408,15 +431,11 @@ static bool executeCodeCore(Icicle* icicle, const size_t& instructionCount)
     if (instructionCount == 0)
     {
         const auto endAddress = codeEndAddress();
-        if (endAddress == 0)
-        {
-           LOG_ERROR("Cannot add end breakpoint before code has been assembled.");
-        }
-        else if (!icicle_add_breakpoint(icicle, endAddress) && !isEndBreakpointSet)
+        if (endAddress != 0 && !icicle_add_breakpoint(icicle, endAddress) && !isEndBreakpointSet)
         {
            LOG_ERROR("Failed to add breakpoint at the end of the assembled code. The program may end unexpectedly.");
         }
-        else
+        else if (endAddress != 0)
         {
             isEndBreakpointSet = true;
         }

--- a/src/app/integration/interpreter/interpreter.hpp
+++ b/src/app/integration/interpreter/interpreter.hpp
@@ -87,6 +87,7 @@ typedef struct{
 } registerValueInfoT;
 
 extern VmSnapshot* saveICSnapshot(Icicle* icicle);
+extern Icicle* initIC();
 extern std::mutex execMutex;
 extern std::mutex breakpointMutex;
 extern bool skipBreakpoints;

--- a/src/app/integration/linuxProcess.cpp
+++ b/src/app/integration/linuxProcess.cpp
@@ -1,0 +1,1091 @@
+#include "linuxProcess.hpp"
+
+#include "interpreter/interpreter.hpp"
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <map>
+#include <optional>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/utsname.h>
+#include <unistd.h>
+#endif
+
+extern void consoleWriteThreadSafe(const std::string& text);
+
+namespace {
+
+constexpr uint64_t kPageSize = 0x1000;
+constexpr uint64_t kLinuxStackTop = 0x7ffffff00000ULL;
+constexpr uint64_t kLinuxStackSize = 8ULL * 1024ULL * 1024ULL;
+constexpr uint64_t kInitialStackZeroSize = 128ULL * 1024ULL;
+constexpr uint64_t kDefaultMmapBase = 0x700000000000ULL;
+constexpr uint64_t kMaxGuestString = 4096;
+constexpr int kEmulatedPid = 4242;
+constexpr int kEmulatedUid = 1000;
+constexpr int kEmulatedGid = 1000;
+
+constexpr uint64_t kAtNull = 0;
+constexpr uint64_t kAtPhdr = 3;
+constexpr uint64_t kAtPhent = 4;
+constexpr uint64_t kAtPhnum = 5;
+constexpr uint64_t kAtPagesz = 6;
+constexpr uint64_t kAtBase = 7;
+constexpr uint64_t kAtFlags = 8;
+constexpr uint64_t kAtEntry = 9;
+constexpr uint64_t kAtUid = 11;
+constexpr uint64_t kAtEuid = 12;
+constexpr uint64_t kAtGid = 13;
+constexpr uint64_t kAtEgid = 14;
+constexpr uint64_t kAtPlatform = 15;
+constexpr uint64_t kAtHwcap = 16;
+constexpr uint64_t kAtClktck = 17;
+constexpr uint64_t kAtSecure = 23;
+constexpr uint64_t kAtRandom = 25;
+constexpr uint64_t kAtHwcap2 = 26;
+constexpr uint64_t kAtExecfn = 31;
+constexpr uint64_t kAtMinsigstksz = 51;
+
+constexpr uint64_t kSysRead = 0;
+constexpr uint64_t kSysWrite = 1;
+constexpr uint64_t kSysOpen = 2;
+constexpr uint64_t kSysClose = 3;
+constexpr uint64_t kSysFstat = 5;
+constexpr uint64_t kSysLseek = 8;
+constexpr uint64_t kSysMmap = 9;
+constexpr uint64_t kSysMprotect = 10;
+constexpr uint64_t kSysMunmap = 11;
+constexpr uint64_t kSysBrk = 12;
+constexpr uint64_t kSysRtSigaction = 13;
+constexpr uint64_t kSysRtSigprocmask = 14;
+constexpr uint64_t kSysIoctl = 16;
+constexpr uint64_t kSysPread64 = 17;
+constexpr uint64_t kSysWritev = 20;
+constexpr uint64_t kSysAccess = 21;
+constexpr uint64_t kSysMremap = 25;
+constexpr uint64_t kSysMadvise = 28;
+constexpr uint64_t kSysGetpid = 39;
+constexpr uint64_t kSysSocket = 41;
+constexpr uint64_t kSysClone = 56;
+constexpr uint64_t kSysExit = 60;
+constexpr uint64_t kSysUname = 63;
+constexpr uint64_t kSysFcntl = 72;
+constexpr uint64_t kSysReadlink = 89;
+constexpr uint64_t kSysGetcwd = 79;
+constexpr uint64_t kSysGettimeofday = 96;
+constexpr uint64_t kSysGetuid = 102;
+constexpr uint64_t kSysGetgid = 104;
+constexpr uint64_t kSysGeteuid = 107;
+constexpr uint64_t kSysGetegid = 108;
+constexpr uint64_t kSysArchPrctl = 158;
+constexpr uint64_t kSysSetTidAddress = 218;
+constexpr uint64_t kSysFutex = 202;
+constexpr uint64_t kSysClockGettime = 228;
+constexpr uint64_t kSysExitGroup = 231;
+constexpr uint64_t kSysOpenat = 257;
+constexpr uint64_t kSysNewfstatat = 262;
+constexpr uint64_t kSysReadlinkat = 267;
+constexpr uint64_t kSysFaccessat = 269;
+constexpr uint64_t kSysSetRobustList = 273;
+constexpr uint64_t kSysPrlimit64 = 302;
+constexpr uint64_t kSysGetrandom = 318;
+constexpr uint64_t kSysRseq = 334;
+
+constexpr int kArchSetFs = 0x1002;
+constexpr int kArchGetFs = 0x1003;
+constexpr int kProtRead = 0x1;
+constexpr int kProtWrite = 0x2;
+constexpr int kProtExec = 0x4;
+constexpr int kMapFixed = 0x10;
+constexpr int kMapAnonymous = 0x20;
+constexpr int kSeekSet = 0;
+constexpr int kSeekCur = 1;
+constexpr int kSeekEnd = 2;
+
+struct GuestFile {
+    std::string path;
+    std::vector<uint8_t> data;
+    uint64_t offset = 0;
+    bool random = false;
+};
+
+struct LinuxProcessState {
+    bool active = false;
+    bool exited = false;
+    int exitCode = 0;
+    LinuxProcessImage image;
+    uint64_t brkCurrent = 0;
+    uint64_t brkMappedEnd = 0;
+    uint64_t mmapNext = kDefaultMmapBase;
+    std::map<int, GuestFile> files;
+    int nextFd = 3;
+    std::unordered_set<uint64_t> warnedSyscalls;
+};
+
+LinuxProcessState gProcess;
+
+uint64_t pageFloor(const uint64_t value)
+{
+    return value & ~(kPageSize - 1);
+}
+
+uint64_t pageCeil(const uint64_t value)
+{
+    return (value + kPageSize - 1) & ~(kPageSize - 1);
+}
+
+uint64_t alignDown(const uint64_t value, const uint64_t alignment)
+{
+    return value & ~(alignment - 1);
+}
+
+std::string formatAddress(const uint64_t value)
+{
+    std::ostringstream out;
+    out << "0x" << std::hex << value;
+    return out.str();
+}
+
+MemoryProtection protectionFromLinuxProt(const uint64_t prot)
+{
+    const bool read = (prot & kProtRead) != 0;
+    const bool write = (prot & kProtWrite) != 0;
+    const bool execute = (prot & kProtExec) != 0;
+
+    if (read && write && execute) return ExecuteReadWrite;
+    if (read && write) return ReadWrite;
+    if (read && execute) return ExecuteRead;
+    if (execute) return ExecuteOnly;
+    if (read) return ReadOnly;
+    if (write) return ReadWrite;
+    return NoAccess;
+}
+
+int64_t negativeErrno(const int error)
+{
+    return -static_cast<int64_t>(error);
+}
+
+void setSyscallReturn(Icicle* vm, const int64_t value)
+{
+    if (vm != nullptr) {
+        icicle_reg_write(vm, "rax", static_cast<uint64_t>(value));
+    }
+}
+
+bool writeGuestBytes(Icicle* vm, const uint64_t address, const void* data, const size_t size)
+{
+    if (size == 0) {
+        return true;
+    }
+    if (vm == nullptr || data == nullptr) {
+        return false;
+    }
+    return icicle_mem_write(vm, address, static_cast<const uint8_t*>(data), size) == 0;
+}
+
+bool writeGuestU64(Icicle* vm, const uint64_t address, const uint64_t value)
+{
+    std::array<uint8_t, 8> bytes{};
+    for (size_t i = 0; i < bytes.size(); ++i) {
+        bytes[i] = static_cast<uint8_t>((value >> (i * 8)) & 0xff);
+    }
+    return writeGuestBytes(vm, address, bytes.data(), bytes.size());
+}
+
+std::optional<uint64_t> readGuestU64(Icicle* vm, const uint64_t address)
+{
+    size_t outSize = 0;
+    unsigned char* raw = icicle_mem_read(vm, address, sizeof(uint64_t), &outSize);
+    if (raw == nullptr || outSize < sizeof(uint64_t)) {
+        if (raw != nullptr) {
+            icicle_free_buffer(raw, outSize);
+        }
+        return std::nullopt;
+    }
+
+    uint64_t value = 0;
+    for (size_t i = 0; i < sizeof(uint64_t); ++i) {
+        value |= static_cast<uint64_t>(raw[i]) << (i * 8);
+    }
+    icicle_free_buffer(raw, outSize);
+    return value;
+}
+
+std::optional<std::vector<uint8_t>> readGuestBytes(Icicle* vm, const uint64_t address, const size_t size)
+{
+    if (size == 0) {
+        return std::vector<uint8_t>{};
+    }
+
+    size_t outSize = 0;
+    unsigned char* raw = icicle_mem_read(vm, address, size, &outSize);
+    if (raw == nullptr) {
+        return std::nullopt;
+    }
+
+    std::vector<uint8_t> bytes(raw, raw + outSize);
+    icicle_free_buffer(raw, outSize);
+    return bytes;
+}
+
+std::optional<std::string> readGuestString(Icicle* vm, const uint64_t address)
+{
+    std::string out;
+    out.reserve(64);
+
+    for (uint64_t i = 0; i < kMaxGuestString; ++i) {
+        size_t outSize = 0;
+        unsigned char* raw = icicle_mem_read(vm, address + i, 1, &outSize);
+        if (raw == nullptr || outSize != 1) {
+            if (raw != nullptr) {
+                icicle_free_buffer(raw, outSize);
+            }
+            return std::nullopt;
+        }
+
+        const char c = static_cast<char>(raw[0]);
+        icicle_free_buffer(raw, outSize);
+        if (c == '\0') {
+            return out;
+        }
+        out.push_back(c);
+    }
+
+    return std::nullopt;
+}
+
+bool readHostFile(const std::string& path, std::vector<uint8_t>& bytes)
+{
+    std::ifstream input(path, std::ios::binary);
+    if (!input.good()) {
+        return false;
+    }
+
+    input.seekg(0, std::ios::end);
+    const auto size = input.tellg();
+    if (size < 0) {
+        return false;
+    }
+    input.seekg(0, std::ios::beg);
+
+    bytes.resize(static_cast<size_t>(size));
+    if (!bytes.empty()) {
+        input.read(reinterpret_cast<char*>(bytes.data()), size);
+    }
+    return input.good() || input.eof();
+}
+
+std::string normalizeGuestPath(const std::string& path)
+{
+    if (path == "/proc/self/exe" || path == "/proc/4242/exe") {
+        return gProcess.image.path;
+    }
+    return path;
+}
+
+bool guestPathExists(const std::string& path)
+{
+    const auto normalized = normalizeGuestPath(path);
+    return normalized == "/dev/urandom" || normalized == "/dev/random" ||
+           std::filesystem::exists(normalized);
+}
+
+int openGuestFile(const std::string& path)
+{
+    const auto normalized = normalizeGuestPath(path);
+    GuestFile file;
+    file.path = normalized;
+
+    if (normalized == "/dev/urandom" || normalized == "/dev/random") {
+        file.random = true;
+    } else if (!readHostFile(normalized, file.data)) {
+        return -1;
+    }
+
+    const int fd = gProcess.nextFd++;
+    gProcess.files[fd] = std::move(file);
+    return fd;
+}
+
+GuestFile* lookupFile(const int fd)
+{
+    auto it = gProcess.files.find(fd);
+    return it != gProcess.files.end() ? &it->second : nullptr;
+}
+
+void fillDeterministicRandom(uint8_t* data, const size_t size)
+{
+    uint64_t x = 0x9e3779b97f4a7c15ULL;
+    for (size_t i = 0; i < size; ++i) {
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        data[i] = static_cast<uint8_t>((x * 0x2545f4914f6cdd1dULL) >> 56);
+    }
+}
+
+int64_t readFromGuestFile(const int fd, const uint64_t buffer, const size_t count)
+{
+    if (fd == 0) {
+        return 0;
+    }
+
+    auto* file = lookupFile(fd);
+    if (file == nullptr) {
+        return negativeErrno(EBADF);
+    }
+
+    std::vector<uint8_t> bytes(count);
+    size_t readCount = 0;
+    if (file->random) {
+        fillDeterministicRandom(bytes.data(), bytes.size());
+        readCount = bytes.size();
+    } else if (file->offset < file->data.size()) {
+        readCount = std::min<size_t>(count, file->data.size() - static_cast<size_t>(file->offset));
+        std::memcpy(bytes.data(), file->data.data() + file->offset, readCount);
+        file->offset += readCount;
+    }
+
+    if (readCount > 0 && !writeGuestBytes(icicle, buffer, bytes.data(), readCount)) {
+        return negativeErrno(EFAULT);
+    }
+
+    return static_cast<int64_t>(readCount);
+}
+
+int64_t preadFromGuestFile(const int fd, const uint64_t buffer, const size_t count, const uint64_t offset)
+{
+    auto* file = lookupFile(fd);
+    if (file == nullptr) {
+        return negativeErrno(EBADF);
+    }
+
+    std::vector<uint8_t> bytes(count);
+    size_t readCount = 0;
+    if (file->random) {
+        fillDeterministicRandom(bytes.data(), bytes.size());
+        readCount = bytes.size();
+    } else if (offset < file->data.size()) {
+        readCount = std::min<size_t>(count, file->data.size() - static_cast<size_t>(offset));
+        std::memcpy(bytes.data(), file->data.data() + offset, readCount);
+    }
+
+    if (readCount > 0 && !writeGuestBytes(icicle, buffer, bytes.data(), readCount)) {
+        return negativeErrno(EFAULT);
+    }
+
+    return static_cast<int64_t>(readCount);
+}
+
+int64_t writeGuestOutput(const int fd, const uint64_t buffer, const size_t count)
+{
+    if (fd != 1 && fd != 2) {
+        return negativeErrno(EBADF);
+    }
+
+    const auto bytes = readGuestBytes(icicle, buffer, count);
+    if (!bytes.has_value()) {
+        return negativeErrno(EFAULT);
+    }
+
+    const std::string text(reinterpret_cast<const char*>(bytes->data()), bytes->size());
+    consoleWriteThreadSafe(std::string(fd == 2 ? "stderr >> " : "stdout >> ") + text);
+    return static_cast<int64_t>(bytes->size());
+}
+
+int64_t writeGuestOutputVector(const int fd, const uint64_t iov, const uint64_t iovCount)
+{
+    if (iovCount > 1024) {
+        return negativeErrno(EINVAL);
+    }
+
+    int64_t total = 0;
+    for (uint64_t i = 0; i < iovCount; ++i) {
+        const auto base = readGuestU64(icicle, iov + (i * 16));
+        const auto len = readGuestU64(icicle, iov + (i * 16) + 8);
+        if (!base.has_value() || !len.has_value()) {
+            return negativeErrno(EFAULT);
+        }
+
+        const auto wrote = writeGuestOutput(fd, *base, static_cast<size_t>(*len));
+        if (wrote < 0) {
+            return wrote;
+        }
+        total += wrote;
+    }
+    return total;
+}
+
+int64_t handleBrk(const uint64_t requested)
+{
+    if (requested == 0) {
+        return static_cast<int64_t>(gProcess.brkCurrent);
+    }
+
+    if (requested < gProcess.image.brkStart) {
+        return static_cast<int64_t>(gProcess.brkCurrent);
+    }
+
+    const uint64_t newMappedEnd = pageCeil(requested);
+    if (newMappedEnd > gProcess.brkMappedEnd) {
+        const uint64_t mapStart = gProcess.brkMappedEnd;
+        const uint64_t mapSize = newMappedEnd - mapStart;
+        if (icicle_mem_map(icicle, mapStart, mapSize, ReadWrite) != 0) {
+            return static_cast<int64_t>(gProcess.brkCurrent);
+        }
+        gProcess.brkMappedEnd = newMappedEnd;
+    }
+
+    gProcess.brkCurrent = requested;
+    return static_cast<int64_t>(gProcess.brkCurrent);
+}
+
+int64_t handleMmap(const SyscallArgs* args)
+{
+    const uint64_t requestedAddress = args->arg0;
+    const uint64_t requestedSize = args->arg1;
+    const uint64_t prot = args->arg2;
+    const uint64_t flags = args->arg3;
+    const int fd = static_cast<int>(args->arg4);
+    const uint64_t fileOffset = args->arg5;
+
+    if (requestedSize == 0) {
+        return negativeErrno(EINVAL);
+    }
+
+    GuestFile* file = nullptr;
+    if ((flags & kMapAnonymous) == 0 && fd >= 0) {
+        file = lookupFile(fd);
+        if (file == nullptr) {
+            return negativeErrno(EBADF);
+        }
+    }
+
+    const uint64_t mapSize = pageCeil(requestedSize);
+    uint64_t address = 0;
+    if ((flags & kMapFixed) != 0 && requestedAddress != 0) {
+        address = pageFloor(requestedAddress);
+        icicle_mem_unmap(icicle, address, mapSize);
+    } else if (requestedAddress != 0) {
+        address = pageFloor(requestedAddress);
+    } else {
+        address = pageCeil(gProcess.mmapNext);
+        gProcess.mmapNext = address + mapSize + kPageSize;
+    }
+
+    const auto protection = protectionFromLinuxProt(prot);
+    if (icicle_mem_map(icicle, address, mapSize, protection) != 0) {
+        return negativeErrno(ENOMEM);
+    }
+
+    std::array<uint8_t, kPageSize> zeros{};
+    for (uint64_t page = address; page < address + mapSize; page += kPageSize) {
+        icicle_mem_write(icicle, page, zeros.data(), zeros.size());
+    }
+
+    if (file != nullptr) {
+        if (!file->random && fileOffset < file->data.size()) {
+            const size_t readCount = std::min<size_t>(
+                static_cast<size_t>(requestedSize),
+                file->data.size() - static_cast<size_t>(fileOffset));
+            if (readCount > 0 &&
+                icicle_mem_write(icicle, requestedAddress != 0 ? requestedAddress : address,
+                                 file->data.data() + fileOffset, readCount) != 0) {
+                return negativeErrno(EFAULT);
+            }
+        }
+    }
+
+    return static_cast<int64_t>(requestedAddress != 0 ? requestedAddress : address);
+}
+
+int64_t handleMprotect(const uint64_t address, const uint64_t size, const uint64_t prot)
+{
+    if (size == 0) {
+        return 0;
+    }
+
+    const uint64_t mapStart = pageFloor(address);
+    const uint64_t mapSize = pageCeil((address - mapStart) + size);
+    return icicle_mem_protect(icicle, mapStart, mapSize, protectionFromLinuxProt(prot)) == 0
+        ? 0
+        : negativeErrno(EINVAL);
+}
+
+int64_t handleMunmap(const uint64_t address, const uint64_t size)
+{
+    if (size == 0) {
+        return negativeErrno(EINVAL);
+    }
+
+    const uint64_t mapStart = pageFloor(address);
+    const uint64_t mapSize = pageCeil((address - mapStart) + size);
+    icicle_mem_unmap(icicle, mapStart, mapSize);
+    return 0;
+}
+
+int64_t handleLseek(const int fd, const int64_t offset, const int whence)
+{
+    auto* file = lookupFile(fd);
+    if (file == nullptr) {
+        return negativeErrno(EBADF);
+    }
+
+    int64_t base = 0;
+    if (whence == kSeekSet) {
+        base = 0;
+    } else if (whence == kSeekCur) {
+        base = static_cast<int64_t>(file->offset);
+    } else if (whence == kSeekEnd) {
+        base = static_cast<int64_t>(file->data.size());
+    } else {
+        return negativeErrno(EINVAL);
+    }
+
+    const int64_t next = base + offset;
+    if (next < 0) {
+        return negativeErrno(EINVAL);
+    }
+
+    file->offset = static_cast<uint64_t>(next);
+    return next;
+}
+
+int64_t writeNativeStat(const std::string& path, const uint64_t guestAddress)
+{
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
+    struct stat st {};
+    const auto normalized = normalizeGuestPath(path);
+    if (normalized == "/dev/urandom" || normalized == "/dev/random") {
+        st.st_mode = S_IFCHR | 0444;
+        st.st_nlink = 1;
+        st.st_blksize = 4096;
+    } else if (::stat(normalized.c_str(), &st) != 0) {
+        return negativeErrno(errno);
+    }
+
+    return writeGuestBytes(icicle, guestAddress, &st, sizeof(st)) ? 0 : negativeErrno(EFAULT);
+#else
+    (void)path;
+    (void)guestAddress;
+    return negativeErrno(ENOSYS);
+#endif
+}
+
+int64_t handleFstat(const int fd, const uint64_t guestAddress)
+{
+    if (fd >= 0 && fd <= 2) {
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
+        struct stat st {};
+        st.st_mode = S_IFCHR | 0600;
+        st.st_nlink = 1;
+        st.st_blksize = 4096;
+        return writeGuestBytes(icicle, guestAddress, &st, sizeof(st)) ? 0 : negativeErrno(EFAULT);
+#else
+        return negativeErrno(ENOSYS);
+#endif
+    }
+
+    const auto* file = lookupFile(fd);
+    if (file == nullptr) {
+        return negativeErrno(EBADF);
+    }
+
+    return writeNativeStat(file->path, guestAddress);
+}
+
+int64_t handleReadlink(const std::string& path, const uint64_t buffer, const uint64_t size)
+{
+    if (size == 0) {
+        return negativeErrno(EINVAL);
+    }
+
+    std::string target;
+    if (path == "/proc/self/exe" || path == "/proc/4242/exe") {
+        target = gProcess.image.path;
+    } else {
+#if defined(__linux__) && !defined(__EMSCRIPTEN__)
+        std::array<char, 4096> hostTarget{};
+        const ssize_t readLen = ::readlink(path.c_str(), hostTarget.data(), hostTarget.size());
+        if (readLen < 0) {
+            return negativeErrno(errno);
+        }
+        target.assign(hostTarget.data(), static_cast<size_t>(readLen));
+#else
+        return negativeErrno(EINVAL);
+#endif
+    }
+
+    const size_t count = std::min<size_t>(target.size(), static_cast<size_t>(size));
+    return writeGuestBytes(icicle, buffer, target.data(), count) ? static_cast<int64_t>(count)
+                                                                : negativeErrno(EFAULT);
+}
+
+int64_t handleClockGettime(const uint64_t guestAddress)
+{
+    const auto now = std::chrono::system_clock::now().time_since_epoch();
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now);
+    const auto nanoseconds = std::chrono::duration_cast<std::chrono::nanoseconds>(now - seconds);
+
+    std::array<uint8_t, 16> timespec{};
+    const uint64_t sec = static_cast<uint64_t>(seconds.count());
+    const uint64_t nsec = static_cast<uint64_t>(nanoseconds.count());
+    std::memcpy(timespec.data(), &sec, sizeof(sec));
+    std::memcpy(timespec.data() + 8, &nsec, sizeof(nsec));
+    return writeGuestBytes(icicle, guestAddress, timespec.data(), timespec.size()) ? 0 : negativeErrno(EFAULT);
+}
+
+int64_t handleGettimeofday(const uint64_t timevalAddress)
+{
+    if (timevalAddress == 0) {
+        return 0;
+    }
+
+    const auto now = std::chrono::system_clock::now().time_since_epoch();
+    const auto seconds = std::chrono::duration_cast<std::chrono::seconds>(now);
+    const auto microseconds = std::chrono::duration_cast<std::chrono::microseconds>(now - seconds);
+
+    std::array<uint8_t, 16> timeval{};
+    const uint64_t sec = static_cast<uint64_t>(seconds.count());
+    const uint64_t usec = static_cast<uint64_t>(microseconds.count());
+    std::memcpy(timeval.data(), &sec, sizeof(sec));
+    std::memcpy(timeval.data() + 8, &usec, sizeof(usec));
+    return writeGuestBytes(icicle, timevalAddress, timeval.data(), timeval.size()) ? 0 : negativeErrno(EFAULT);
+}
+
+int64_t handleUname(const uint64_t guestAddress)
+{
+    std::array<char, 390> uts{};
+    auto copyField = [&](const size_t index, const std::string& value) {
+        constexpr size_t fieldSize = 65;
+        std::memcpy(uts.data() + (index * fieldSize), value.c_str(), std::min(value.size(), fieldSize - 1));
+    };
+
+    copyField(0, "Linux");
+    copyField(1, "zathura");
+    copyField(2, "6.10.0-zathura");
+    copyField(3, "#1 ZathuraDbg");
+    copyField(4, "x86_64");
+    copyField(5, "localdomain");
+    return writeGuestBytes(icicle, guestAddress, uts.data(), uts.size()) ? 0 : negativeErrno(EFAULT);
+}
+
+int64_t handlePrlimit64(const uint64_t oldLimitAddress)
+{
+    if (oldLimitAddress == 0) {
+        return 0;
+    }
+
+    std::array<uint8_t, 16> rlimit{};
+    const uint64_t soft = kLinuxStackSize;
+    const uint64_t hard = kLinuxStackSize;
+    std::memcpy(rlimit.data(), &soft, sizeof(soft));
+    std::memcpy(rlimit.data() + 8, &hard, sizeof(hard));
+    return writeGuestBytes(icicle, oldLimitAddress, rlimit.data(), rlimit.size()) ? 0 : negativeErrno(EFAULT);
+}
+
+int64_t handleArchPrctl(const uint64_t code, const uint64_t address)
+{
+    if (code == kArchSetFs) {
+        return icicle_reg_write(icicle, "fs_base", address) == 0 ? 0 : negativeErrno(EINVAL);
+    }
+
+    if (code == kArchGetFs) {
+        uint64_t fsBase = 0;
+        if (icicle_reg_read(icicle, "fs_base", &fsBase) != 0) {
+            return negativeErrno(EINVAL);
+        }
+        return writeGuestU64(icicle, address, fsBase) ? 0 : negativeErrno(EFAULT);
+    }
+
+    return negativeErrno(EINVAL);
+}
+
+int64_t handleFcntl(const int fd, const uint64_t cmd)
+{
+    if ((fd < 0 || fd > 2) && lookupFile(fd) == nullptr) {
+        return negativeErrno(EBADF);
+    }
+
+    if (cmd == 1) {
+        return 0;
+    }
+    if (cmd == 2 || cmd == 3) {
+        return 0;
+    }
+    return 0;
+}
+
+void warnUnsupportedSyscallOnce(const uint64_t syscallNumber)
+{
+    if (gProcess.warnedSyscalls.insert(syscallNumber).second) {
+        consoleWriteThreadSafe("linux >> unsupported syscall " + std::to_string(syscallNumber) + " -> -ENOSYS\n");
+    }
+}
+
+std::vector<std::string> defaultEnvironment()
+{
+    return {
+        "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+        "HOME=/",
+        "USER=rc",
+        "LOGNAME=rc",
+        "LANG=C",
+        "TERM=xterm-256color",
+    };
+}
+
+} // namespace
+
+bool configureLinuxProcess(const LinuxProcessImage& image)
+{
+    gProcess = LinuxProcessState{};
+    gProcess.active = true;
+    gProcess.image = image;
+    gProcess.brkCurrent = image.brkStart;
+    gProcess.brkMappedEnd = pageCeil(image.brkStart);
+    gProcess.mmapNext = kDefaultMmapBase;
+    return true;
+}
+
+bool setupLinuxProcessStack(Icicle* vm)
+{
+    if (vm == nullptr || !gProcess.active) {
+        return false;
+    }
+
+    STACK_ADDRESS = kLinuxStackTop - kLinuxStackSize;
+    STACK_SIZE = kLinuxStackSize;
+
+    if (icicle_mem_map(vm, STACK_ADDRESS, STACK_SIZE, ReadWrite) != 0) {
+        consoleWriteThreadSafe("linux >> failed to map process stack at " + formatAddress(STACK_ADDRESS) + "\n");
+        return false;
+    }
+
+    const uint64_t zeroSize = std::min(kInitialStackZeroSize, kLinuxStackSize);
+    const uint64_t zeroStart = kLinuxStackTop - zeroSize;
+    std::array<uint8_t, kPageSize> zeros{};
+    for (uint64_t address = zeroStart; address < kLinuxStackTop; address += kPageSize) {
+        if (icicle_mem_write(vm, address, zeros.data(), zeros.size()) != 0) {
+            consoleWriteThreadSafe("linux >> failed to zero process stack\n");
+            return false;
+        }
+    }
+
+    const std::vector<std::string> argv = {gProcess.image.path};
+    const auto envp = defaultEnvironment();
+    std::vector<uint64_t> argvAddresses;
+    std::vector<uint64_t> envpAddresses;
+
+    uint64_t cursor = kLinuxStackTop;
+    auto pushString = [&](const std::string& value) -> std::optional<uint64_t> {
+        cursor -= value.size() + 1;
+        if (!writeGuestBytes(vm, cursor, value.c_str(), value.size() + 1)) {
+            return std::nullopt;
+        }
+        return cursor;
+    };
+
+    for (auto it = argv.rbegin(); it != argv.rend(); ++it) {
+        auto address = pushString(*it);
+        if (!address.has_value()) return false;
+        argvAddresses.push_back(*address);
+    }
+    std::reverse(argvAddresses.begin(), argvAddresses.end());
+
+    for (auto it = envp.rbegin(); it != envp.rend(); ++it) {
+        auto address = pushString(*it);
+        if (!address.has_value()) return false;
+        envpAddresses.push_back(*address);
+    }
+    std::reverse(envpAddresses.begin(), envpAddresses.end());
+
+    const auto execfnAddress = pushString(gProcess.image.path);
+    const auto platformAddress = pushString("x86_64");
+    if (!execfnAddress.has_value() || !platformAddress.has_value()) {
+        return false;
+    }
+
+    cursor = alignDown(cursor - 16, 16);
+    std::array<uint8_t, 16> randomBytes{};
+    fillDeterministicRandom(randomBytes.data(), randomBytes.size());
+    if (!writeGuestBytes(vm, cursor, randomBytes.data(), randomBytes.size())) {
+        return false;
+    }
+    const uint64_t randomAddress = cursor;
+
+    std::vector<std::pair<uint64_t, uint64_t>> auxv = {
+        {kAtPhdr, gProcess.image.programHeaders},
+        {kAtPhent, gProcess.image.programHeaderEntrySize},
+        {kAtPhnum, gProcess.image.programHeaderCount},
+        {kAtPagesz, kPageSize},
+        {kAtBase, gProcess.image.interpreterBase},
+        {kAtFlags, 0},
+        {kAtEntry, gProcess.image.programEntry},
+        {kAtUid, kEmulatedUid},
+        {kAtEuid, kEmulatedUid},
+        {kAtGid, kEmulatedGid},
+        {kAtEgid, kEmulatedGid},
+        {kAtSecure, 0},
+        {kAtRandom, randomAddress},
+        {kAtHwcap, 0},
+        {kAtHwcap2, 0},
+        {kAtClktck, 100},
+        {kAtPlatform, *platformAddress},
+        {kAtExecfn, *execfnAddress},
+        {kAtMinsigstksz, 2048},
+        {kAtNull, 0},
+    };
+
+    std::vector<uint64_t> words;
+    words.push_back(argvAddresses.size());
+    words.insert(words.end(), argvAddresses.begin(), argvAddresses.end());
+    words.push_back(0);
+    words.insert(words.end(), envpAddresses.begin(), envpAddresses.end());
+    words.push_back(0);
+    for (const auto& [type, value] : auxv) {
+        words.push_back(type);
+        words.push_back(value);
+    }
+
+    cursor = alignDown(cursor - (words.size() * sizeof(uint64_t)), 16);
+    for (size_t i = 0; i < words.size(); ++i) {
+        if (!writeGuestU64(vm, cursor + (i * sizeof(uint64_t)), words[i])) {
+            return false;
+        }
+    }
+
+    icicle_reg_write(vm, "rsp", cursor);
+    icicle_reg_write(vm, "rbp", cursor);
+    return true;
+}
+
+void clearLinuxProcess()
+{
+    gProcess = LinuxProcessState{};
+    STACK_ADDRESS = DEFAULT_STACK_ADDRESS;
+    STACK_SIZE = 64ULL * 1024ULL;
+}
+
+bool linuxProcessActive()
+{
+    return gProcess.active;
+}
+
+bool linuxProcessExited()
+{
+    return gProcess.active && gProcess.exited;
+}
+
+int linuxProcessExitCode()
+{
+    return gProcess.exitCode;
+}
+
+int handleLinuxProcessSyscall(void* data, const uint64_t syscallNumber, const SyscallArgs* args)
+{
+    auto* vm = static_cast<Icicle*>(data);
+    if (vm == nullptr || args == nullptr || !gProcess.active) {
+        return 0;
+    }
+
+    icicle = vm;
+    int64_t result = 0;
+    int hookResult = 0;
+
+    switch (syscallNumber) {
+        case kSysRead:
+            result = readFromGuestFile(static_cast<int>(args->arg0), args->arg1, static_cast<size_t>(args->arg2));
+            break;
+        case kSysWrite:
+            result = writeGuestOutput(static_cast<int>(args->arg0), args->arg1, static_cast<size_t>(args->arg2));
+            break;
+        case kSysOpen: {
+            const auto path = readGuestString(vm, args->arg0);
+            if (!path.has_value()) {
+                result = negativeErrno(EFAULT);
+            } else if (const int fd = openGuestFile(*path); fd >= 0) {
+                result = fd;
+            } else {
+                result = negativeErrno(ENOENT);
+            }
+            break;
+        }
+        case kSysOpenat: {
+            const auto path = readGuestString(vm, args->arg1);
+            if (!path.has_value()) {
+                result = negativeErrno(EFAULT);
+            } else if (const int fd = openGuestFile(*path); fd >= 0) {
+                result = fd;
+            } else {
+                result = negativeErrno(ENOENT);
+            }
+            break;
+        }
+        case kSysClose:
+            if (args->arg0 <= 2) {
+                result = 0;
+            } else {
+                result = gProcess.files.erase(static_cast<int>(args->arg0)) ? 0 : negativeErrno(EBADF);
+            }
+            break;
+        case kSysFstat:
+            result = handleFstat(static_cast<int>(args->arg0), args->arg1);
+            break;
+        case kSysNewfstatat: {
+            const auto path = readGuestString(vm, args->arg1);
+            result = path.has_value() ? writeNativeStat(*path, args->arg2) : negativeErrno(EFAULT);
+            break;
+        }
+        case kSysLseek:
+            result = handleLseek(static_cast<int>(args->arg0), static_cast<int64_t>(args->arg1), static_cast<int>(args->arg2));
+            break;
+        case kSysPread64:
+            result = preadFromGuestFile(static_cast<int>(args->arg0), args->arg1,
+                                        static_cast<size_t>(args->arg2), args->arg3);
+            break;
+        case kSysWritev:
+            result = writeGuestOutputVector(static_cast<int>(args->arg0), args->arg1, args->arg2);
+            break;
+        case kSysMmap:
+            result = handleMmap(args);
+            break;
+        case kSysMprotect:
+            result = handleMprotect(args->arg0, args->arg1, args->arg2);
+            break;
+        case kSysMunmap:
+            result = handleMunmap(args->arg0, args->arg1);
+            break;
+        case kSysMremap:
+            result = negativeErrno(ENOSYS);
+            break;
+        case kSysMadvise:
+            result = 0;
+            break;
+        case kSysBrk:
+            result = handleBrk(args->arg0);
+            break;
+        case kSysAccess: {
+            const auto path = readGuestString(vm, args->arg0);
+            result = path.has_value() && guestPathExists(*path) ? 0 : negativeErrno(ENOENT);
+            break;
+        }
+        case kSysReadlink: {
+            const auto path = readGuestString(vm, args->arg0);
+            result = path.has_value() ? handleReadlink(*path, args->arg1, args->arg2) : negativeErrno(EFAULT);
+            break;
+        }
+        case kSysReadlinkat: {
+            const auto path = readGuestString(vm, args->arg1);
+            result = path.has_value() ? handleReadlink(*path, args->arg2, args->arg3) : negativeErrno(EFAULT);
+            break;
+        }
+        case kSysFaccessat: {
+            const auto path = readGuestString(vm, args->arg1);
+            result = path.has_value() && guestPathExists(*path) ? 0 : negativeErrno(ENOENT);
+            break;
+        }
+        case kSysGetcwd: {
+            const std::string cwd = "/";
+            if (args->arg1 < cwd.size() + 1) {
+                result = negativeErrno(ERANGE);
+            } else {
+                result = writeGuestBytes(vm, args->arg0, cwd.c_str(), cwd.size() + 1)
+                    ? static_cast<int64_t>(cwd.size() + 1)
+                    : negativeErrno(EFAULT);
+            }
+            break;
+        }
+        case kSysClockGettime:
+            result = handleClockGettime(args->arg1);
+            break;
+        case kSysGettimeofday:
+            result = handleGettimeofday(args->arg0);
+            break;
+        case kSysUname:
+            result = handleUname(args->arg0);
+            break;
+        case kSysPrlimit64:
+            result = handlePrlimit64(args->arg3);
+            break;
+        case kSysArchPrctl:
+            result = handleArchPrctl(args->arg0, args->arg1);
+            break;
+        case kSysSetTidAddress:
+            result = kEmulatedPid;
+            break;
+        case kSysSetRobustList:
+        case kSysRtSigaction:
+        case kSysRtSigprocmask:
+            result = 0;
+            break;
+        case kSysFutex:
+            result = 0;
+            break;
+        case kSysFcntl:
+            result = handleFcntl(static_cast<int>(args->arg0), args->arg1);
+            break;
+        case kSysGetpid:
+            result = kEmulatedPid;
+            break;
+        case kSysGetuid:
+        case kSysGeteuid:
+            result = kEmulatedUid;
+            break;
+        case kSysGetgid:
+        case kSysGetegid:
+            result = kEmulatedGid;
+            break;
+        case kSysGetrandom: {
+            std::vector<uint8_t> bytes(static_cast<size_t>(args->arg1));
+            fillDeterministicRandom(bytes.data(), bytes.size());
+            result = writeGuestBytes(vm, args->arg0, bytes.data(), bytes.size())
+                ? static_cast<int64_t>(bytes.size())
+                : negativeErrno(EFAULT);
+            break;
+        }
+        case kSysRseq:
+            result = negativeErrno(ENOSYS);
+            break;
+        case kSysIoctl:
+            result = negativeErrno(ENOTTY);
+            break;
+        case kSysSocket:
+        case kSysClone:
+            result = negativeErrno(ENOSYS);
+            break;
+        case kSysExit:
+            gProcess.exited = true;
+            gProcess.exitCode = static_cast<int>(args->arg0 & 0xff);
+            result = 0;
+            break;
+        case kSysExitGroup:
+            gProcess.exited = true;
+            gProcess.exitCode = static_cast<int>(args->arg0 & 0xff);
+            result = 0;
+            hookResult = -1;
+            break;
+        default:
+            warnUnsupportedSyscallOnce(syscallNumber);
+            result = negativeErrno(ENOSYS);
+            break;
+    }
+
+    setSyscallReturn(vm, result);
+    return hookResult;
+}

--- a/src/app/integration/linuxProcess.hpp
+++ b/src/app/integration/linuxProcess.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "icicle.h"
+
+struct LinuxProcessImage {
+    std::string path;
+    std::string interpreterPath;
+
+    uint64_t initialPc = 0;
+    uint64_t programEntry = 0;
+    uint64_t programHeaders = 0;
+    uint64_t programHeaderEntrySize = 0;
+    uint64_t programHeaderCount = 0;
+    uint64_t interpreterBase = 0;
+    uint64_t loadBias = 0;
+    uint64_t brkStart = 0;
+};
+
+bool configureLinuxProcess(const LinuxProcessImage& image);
+bool setupLinuxProcessStack(Icicle* vm);
+void clearLinuxProcess();
+bool linuxProcessActive();
+bool linuxProcessExited();
+int linuxProcessExitCode();
+int handleLinuxProcessSyscall(void* data, uint64_t syscallNumber, const SyscallArgs* args);

--- a/src/app/tasks/fileTasks.cpp
+++ b/src/app/tasks/fileTasks.cpp
@@ -57,12 +57,11 @@ void fileSaveAsTask(const std::string &fileName){
 void fileSaveTask(const std::string &fileName){
     if (!fileName.empty()){
         LOG_DEBUG("Saving the file " << fileName);
-        if (!writeEditorToFile(selectedFile)) {
+        if (!writeEditorToFile(fileName)) {
             LOG_ERROR("Save operation failed on the file: " << fileName << " !");
         }
 
         selectedFile = fileName;
-        fileOpenTask(selectedFile);
     }
 }
 

--- a/src/app/tasks/fileTasks.cpp
+++ b/src/app/tasks/fileTasks.cpp
@@ -1,6 +1,7 @@
 #include "fileTasks.hpp"
 #include <mutex>
 #include "../app.hpp"
+#include "../integration/elfLoader.hpp"
 
 std::filesystem::path getTemporaryPath(){
     std::filesystem::path tempDir;
@@ -21,6 +22,11 @@ static std::mutex icicleMutex;
 bool fileOpenTask(const std::string& fileName){
     if (!fileName.empty()){
         LOG_DEBUG("Opening the file " << fileName);
+        if (isElfBinaryFile(fileName)) {
+            return loadElfBinaryForDebug(fileName);
+        }
+
+        clearLocalElfBinary();
         resetState(false);
         if (!readFileIntoEditor(fileName)){
             LOG_ERROR("Read operation failed on the file: " << fileName);

--- a/src/app/windows/stackWindow.cpp
+++ b/src/app/windows/stackWindow.cpp
@@ -1,18 +1,32 @@
 #include "windows.hpp"
 #include "../integration/debugState.hpp"
 
+#include <algorithm>
+
 MemoryEditor stackEditor;
 
 namespace {
 
+constexpr size_t kMaxStackDisplaySize = 64ULL * 1024ULL;
+uint64_t g_stackDisplayBase = 0;
 size_t g_stackDisplaySize = 0;
+
+size_t currentStackDisplayRange()
+{
+    return static_cast<size_t>(std::min<uintptr_t>(STACK_SIZE, kMaxStackDisplaySize));
+}
+
+uint64_t currentStackDisplayBase(const size_t displayRange)
+{
+    return STACK_ADDRESS + (STACK_SIZE > displayRange ? STACK_SIZE - displayRange : 0);
+}
 
 bool stackDiffHighlightFn(const ImU8*, const size_t off) {
     if (g_stackDisplaySize == 0 || off >= g_stackDisplaySize) {
         return false;
     }
 
-    const uint64_t address = STACK_ADDRESS + g_stackDisplaySize - off - 1;
+    const uint64_t address = g_stackDisplayBase + g_stackDisplaySize - off - 1;
     return isDebugStackMemoryChanged(address);
 }
 
@@ -20,6 +34,10 @@ bool stackDiffHighlightFn(const ImU8*, const size_t off) {
 
 static void* copyBigEndian(void* dst, const void* src, size_t size)
 {
+    if (size == 0) {
+        return dst;
+    }
+
     uint8_t* dst_ptr = static_cast<uint8_t*>(dst);
     const uint8_t* src_ptr = static_cast<const uint8_t*>(src) + size - 1;
 
@@ -44,13 +62,13 @@ void stackWriteFunc(ImU8* data, const size_t offset, const ImU8 delta) {
         std::lock_guard<std::mutex> lk(debugReadyMutex);
     }
 
-    const size_t displayedSize = g_stackDisplaySize > 0 ? g_stackDisplaySize : STACK_SIZE;
+    const size_t displayedSize = g_stackDisplaySize > 0 ? g_stackDisplaySize : currentStackDisplayRange();
     if (offset >= displayedSize) {
         LOG_ERROR("Stack write offset is outside the displayed stack range. Offset: " << offset);
         return;
     }
 
-    const uint64_t address = STACK_ADDRESS + displayedSize - offset - 1;
+    const uint64_t address = g_stackDisplayBase + displayedSize - offset - 1;
     LOG_INFO("Stack write at 0x" << std::hex << address << ": " << static_cast<int>(delta));
 
     const bool writeOk = writeDebugMemory(address, delta);
@@ -91,18 +109,37 @@ bool handleStackError() {
 }
 
 static std::unique_ptr<unsigned char[], decltype(&free)> stackBuffer(nullptr, free);
+static size_t stackBufferSize = 0;
 
 void stackEditorWindow() {
     const auto io = ImGui::GetIO();
     ImGui::PushFont(io.Fonts->Fonts[3]);
 
+    const size_t stackDisplayRange = currentStackDisplayRange();
+    const uint64_t stackDisplayBase = currentStackDisplayBase(stackDisplayRange);
+    const size_t requiredBufferSize = std::max<size_t>(stackDisplayRange, 1);
+
+    if (!stackBuffer || stackBufferSize != requiredBufferSize) {
+        stackBuffer.reset(static_cast<unsigned char*>(calloc(1, requiredBufferSize)));
+        stackBufferSize = stackBuffer ? requiredBufferSize : 0;
+    }
     if (!stackBuffer) {
-        stackBuffer.reset(static_cast<unsigned char*>(calloc(1, STACK_SIZE)));
+        ImGui::Text("Unable to allocate stack view buffer.");
+        ImGui::PopFont();
+        return;
     }
 
     if (!remote_gdb::useRemoteDebugging() && icicle && isDebugReady)
     {
         static bool stack_mapped_once = false;
+        static uintptr_t mappedStackAddress = 0;
+        static uintptr_t mappedStackSize = 0;
+        if (mappedStackAddress != STACK_ADDRESS || mappedStackSize != STACK_SIZE) {
+            stack_mapped_once = false;
+            mappedStackAddress = STACK_ADDRESS;
+            mappedStackSize = STACK_SIZE;
+        }
+
         if (!stack_mapped_once) {
             LOG_INFO("Stack mapping if not done already");
 
@@ -131,12 +168,15 @@ void stackEditorWindow() {
     std::optional<std::vector<uint8_t>> memData;
     static size_t remoteStackReadable = 0;
     static uintptr_t lastStackAddr = 0;
+    static size_t lastStackDisplayRange = 0;
     static bool remoteStackProbeFailed = false;
     static uint64_t lastStackResumeGen = ~uint64_t{0};
 
-    if (lastStackAddr != STACK_ADDRESS || lastStackResumeGen != remoteResumeGeneration) {
+    if (lastStackAddr != stackDisplayBase || lastStackDisplayRange != stackDisplayRange ||
+        lastStackResumeGen != remoteResumeGeneration) {
         remoteStackReadable = 0;
-        lastStackAddr = STACK_ADDRESS;
+        lastStackAddr = stackDisplayBase;
+        lastStackDisplayRange = stackDisplayRange;
         lastStackResumeGen = remoteResumeGeneration;
         remoteStackProbeFailed = false;
     }
@@ -144,8 +184,8 @@ void stackEditorWindow() {
     if (isDebugReady) {
         if (remote_gdb::useRemoteDebugging()) {
             if (!remoteStackProbeFailed) {
-                const size_t trySize = remoteStackReadable > 0 ? remoteStackReadable : STACK_SIZE;
-                memData = remote_gdb::remoteReadMemoryWithFallback(STACK_ADDRESS, trySize);
+                const size_t trySize = remoteStackReadable > 0 ? remoteStackReadable : stackDisplayRange;
+                memData = remote_gdb::remoteReadMemoryWithFallback(stackDisplayBase, trySize);
                 if (memData.has_value()) {
                     remoteStackReadable = memData->size();
                 } else {
@@ -154,16 +194,19 @@ void stackEditorWindow() {
                 }
             }
         } else {
-            memData = readDebugMemory(STACK_ADDRESS, STACK_SIZE);
+            memData = readDebugMemory(stackDisplayBase, stackDisplayRange);
         }
     }
 
-    const size_t displaySize = memData.has_value() ? memData->size() : STACK_SIZE;
+    const size_t displaySize = memData.has_value() ? memData->size() : stackDisplayRange;
+    g_stackDisplayBase = stackDisplayBase;
     g_stackDisplaySize = displaySize;
 
-    memset(stackBuffer.get(), 0, STACK_SIZE);
+    if (stackBuffer) {
+        memset(stackBuffer.get(), 0, stackBufferSize);
+    }
     if (memData.has_value()) {
-        trackDebugStackMemory(STACK_ADDRESS, *memData);
+        trackDebugStackMemory(stackDisplayBase, *memData);
         copyBigEndian(stackBuffer.get(), memData->data(), memData->size());
     }
 
@@ -175,7 +218,7 @@ void stackEditorWindow() {
     stackEditor.StackFashionAddrSubtraction = true;
     stackEditor.WriteFn = &stackWriteFunc;
 
-    stackEditor.DrawWindow("Stack", reinterpret_cast<void*>(stackBuffer.get()), displaySize, STACK_ADDRESS + displaySize);
+    stackEditor.DrawWindow("Stack", reinterpret_cast<void*>(stackBuffer.get()), displaySize, stackDisplayBase + displaySize);
 
     if (!newMemEditWindows.empty()) {
         int i = 0;


### PR DESCRIPTION
## Summary
Fixes two bugs in `fileSaveTask` (`src/app/tasks/fileTasks.cpp`) that made saving fragile and crash-prone.

1. **Wrong file written** — it called `writeEditorToFile(selectedFile)` instead of the `fileName` argument passed in. Now writes `fileName`.
2. **Heavy re-open on every save** — it called `fileOpenTask(selectedFile)` after writing, which tore down and rebuilt emulator/editor state (`clearLocalElfBinary`, `resetState`, `readFileIntoEditor`, `getBytes` re-assemble, `HighlightBreakpoints`). This is the likely crash when saving, especially mid-debug. Removed it.

The function now mirrors the correct `fileSaveAsTask` pattern: write the target file, update `selectedFile`, no re-open.