### PR TITLE
Add repeatable AppImage build and release workflow

### DIFF
--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -1,0 +1,43 @@
+name: appimage
+
+# Build the Linux AppImage and attach it to the GitHub Release whenever a tag
+# is pushed. The emulator/assembler libs are committed under vendor/local, so
+# the build only needs system deps from apt (no Rust step). vendor/ is part of
+# the main tree (no submodules), so a normal checkout is sufficient.
+on:
+  push:
+    tags:
+      - '*'
+
+permissions:
+  contents: write
+
+jobs:
+  appimage:
+    runs-on: ubuntu-latest
+    env:
+      ARCH: x86_64
+    steps:
+      - name: Checkout (with tag)
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            cmake ninja-build pkg-config g++-14 gcc-14 \
+            libglfw3-dev libgl1-mesa-dev \
+            libcapstone-dev libssl-dev nlohmann-json3-dev
+
+      - name: Build AppImage
+        run: bash packaging/build-appimage.sh
+
+      - name: Publish AppImage to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: Zathura_Debugger-x86_64.AppImage
+          fail_on_unmatched_files: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -7,7 +7,9 @@ name: appimage
 on:
   push:
     tags:
-      - '*'
+      # Release tags only (this project tags as 1.0, 0.5.0-beta, ...), so
+      # scratch tags like "wip" or "backup" do not trigger a public release.
+      - '[0-9]+.*'
 
 permissions:
   contents: write

--- a/.github/workflows/appimage.yml
+++ b/.github/workflows/appimage.yml
@@ -39,7 +39,9 @@ jobs:
       - name: Publish AppImage to release
         uses: softprops/action-gh-release@v2
         with:
-          files: Zathura_Debugger-x86_64.AppImage
+          # Glob so the upload stays correct if ARCH changes; the build script
+          # names the artifact Zathura_Debugger-${ARCH}.AppImage.
+          files: Zathura_Debugger-*.AppImage
           fail_on_unmatched_files: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,11 @@ src/Zathura.worker.js
 # IDE files (already partially covered but .idea is tracked)
 .idea/
 
+# AppImage packaging outputs
+/AppDir/
+/Zathura_Debugger-*.AppImage
+packaging/.cache/
+
 # Vendor prebuilt binaries
 vendor/**/*.dll
 vendor/**/*.dylib

--- a/packaging/.gitignore
+++ b/packaging/.gitignore
@@ -1,0 +1,2 @@
+# Cached appimagetool download
+.cache/

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,112 @@
+# Packaging ZathuraDbg as an AppImage
+
+This directory contains a repeatable build + publishing pipeline that produces
+`Zathura_Debugger-x86_64.AppImage`, reproducing the layout of the project's
+released AppImage.
+
+## Build locally
+
+```bash
+bash packaging/build-appimage.sh
+```
+
+This will:
+
+1. Read the version from the repo `VERSION` file (override with `VERSION=...`).
+2. Configure + build a Release `Zathura` with CMake/Ninja
+   (`cmake -S src -B src/build -G Ninja -DCMAKE_BUILD_TYPE=Release`, then
+   `cmake --build src/build`). gcc-14/g++-14 are used when available, matching CI.
+3. Assemble an `AppDir/` and run `appimagetool` to emit
+   `Zathura_Debugger-x86_64.AppImage` in the repo root.
+
+`appimagetool` is downloaded once into `packaging/.cache/` (git-ignored) and is
+invoked with `--appimage-extract-and-run`, so **FUSE is not required** (works in
+CI containers).
+
+### Packaging a prebuilt binary
+
+If you already have a built binary at `src/Zathura` (or `src/build/Zathura`) and
+just want to repackage:
+
+```bash
+bash packaging/build-appimage.sh --no-build
+```
+
+### Useful environment overrides
+
+| Variable    | Default                     | Meaning                                   |
+|-------------|-----------------------------|-------------------------------------------|
+| `VERSION`   | contents of `VERSION` file  | version embedded by appimagetool          |
+| `OUTPUT`    | repo root                   | output directory for the `.AppImage`      |
+| `STRIP`     | `1` (strip)                 | set `0` to keep debug symbols in binary   |
+| `ARCH`      | `x86_64`                    | target architecture                       |
+| `CACHE_DIR` | `packaging/.cache`          | where `appimagetool` is cached            |
+
+## Publishing (push a tag)
+
+Publishing is fully automated by `.github/workflows/appimage.yml`, which is
+triggered **only on tag pushes**:
+
+```bash
+git tag v1.0
+git push origin v1.0
+```
+
+The workflow runs on `ubuntu-latest`, installs the apt build deps, runs
+`packaging/build-appimage.sh`, and uploads the resulting
+`Zathura_Debugger-x86_64.AppImage` to the GitHub Release for that tag via
+`softprops/action-gh-release@v2` (using the built-in `GITHUB_TOKEN`;
+the job has `permissions: contents: write`).
+
+## AppDir layout
+
+```
+AppDir/
+  AppRun                         bash launcher (exports LD_LIBRARY_PATH/PATH, execs the binary)
+  ZathuraDbg.desktop             top-level desktop entry
+  ZathuraDbg.png                 top-level icon
+  .DirIcon -> ZathuraDbg.png
+  usr/bin/Zathura                the built executable
+  usr/lib/                       bundled shared libraries (see below)
+  usr/assets/                    copy of repo assets/ (fonts + icon)
+  usr/vendor/ghidra/             copy of repo vendor/ghidra/ (processor specs)
+  usr/share/applications/ZathuraDbg.desktop
+  usr/share/icons/hicolor/256x256/apps/ZathuraDbg.png
+```
+
+**Critical:** ZathuraDbg loads its data via paths *relative to the executable* —
+`../assets/...` for fonts/icon and `../vendor/ghidra/` for processor specs (see
+`src/main.cpp`). With the binary at `usr/bin/Zathura` these resolve to
+`usr/assets/` and `usr/vendor/ghidra/`. Do not move these directories.
+
+## Library bundling and glibc notes
+
+The AppImage bundles only libraries that cannot be assumed present on a target
+system. The vendored keystone (`vendor/local/usr/local/lib/libkeystone.so.0`) is
+always bundled; everything else is derived from `ldd` against the built binary
+and filtered through an allowlist:
+
+```
+libglfw.so.3  libGLU.so.1  libssl.so.3  libcrypto.so.3
+libXau.so.6   libXdmcp.so.6  libkeystone.so.0  libunicorn.so.2
+```
+
+`libunicorn.so.2` is only present if the binary actually links it; current builds
+use the statically-linked icicle emulator and will not bundle unicorn.
+
+The following are **deliberately not bundled** and must come from the host: the
+C/C++ runtime (`libc`, `libstdc++`, `libgcc_s`, `libm`, `libdl`), the Mesa GL
+driver (`libGL`), and core X11/xcb. Bundling these breaks graphics or causes
+runtime ABI mismatches.
+
+Because the runtime is taken from the host, the AppImage requires a glibc at
+least as new as the build runner's. It is built on `ubuntu-latest`, which is in
+line with the project's stated **glibc 2.38+** requirement.
+
+### Difference from the original released AppImage
+
+The released image accidentally shipped `libicicle.a` (a ~45 MB static archive)
+in `usr/lib/`. A static `.a` is linked at build time and never loaded at runtime,
+so this script **does not** bundle it — dead weight, functionally identical.
+The binary is also stripped by default (the released one was unstripped),
+which is skippable via `STRIP=0`.

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -126,6 +126,16 @@ if [[ "${STRIP_BINARY}" != "0" ]] && command -v strip >/dev/null 2>&1; then
         echo "    (strip failed, continuing with unstripped binary)"
 fi
 
+# 3a-bis. Default sample file. The app opens "test.asm" relative to the
+# executable on startup (see src/main.cpp), so it must sit next to the binary
+# at usr/bin/test.asm. Without it the first launch fails to load a default file.
+if [[ -f "${REPO_ROOT}/src/test.asm" ]]; then
+    echo "==> Bundling default test.asm"
+    cp -f "${REPO_ROOT}/src/test.asm" "${APPDIR}/usr/bin/test.asm"
+else
+    echo "    (warning: src/test.asm not found; AppImage will start without a default file)"
+fi
+
 # 3b. Bundle shared libraries.
 #
 # Strategy: ship the vendored keystone, plus an allowlist of libs that are not

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+#
+# build-appimage.sh - Repeatable AppImage builder for ZathuraDbg.
+#
+# Produces "Zathura_Debugger-x86_64.AppImage" reproducing the layout of the
+# project's released AppImage:
+#
+#   AppDir/
+#     AppRun                        bash launcher (exports LD_LIBRARY_PATH/PATH)
+#     ZathuraDbg.desktop            top-level desktop entry
+#     ZathuraDbg.png                top-level icon
+#     .DirIcon -> ZathuraDbg.png
+#     usr/bin/Zathura               the built executable
+#     usr/lib/                      bundled shared libraries (allowlist below)
+#     usr/assets/                   copy of repo assets/ (fonts + icon)
+#     usr/vendor/ghidra/            copy of repo vendor/ghidra/ (processor specs)
+#     usr/share/applications/ZathuraDbg.desktop
+#     usr/share/icons/hicolor/256x256/apps/ZathuraDbg.png
+#
+# IMPORTANT: the binary loads data via paths relative to itself ("../assets/"
+# and "../vendor/ghidra/"). With the binary at usr/bin/Zathura those resolve to
+# usr/assets/ and usr/vendor/ghidra/. Do not move these.
+#
+# Usage:
+#   bash packaging/build-appimage.sh            # build + package
+#   bash packaging/build-appimage.sh --no-build # package an existing binary
+#
+# Environment overrides:
+#   VERSION       override version (default: contents of repo VERSION file)
+#   OUTPUT        output directory for the .AppImage (default: repo root)
+#   STRIP         "0" to skip stripping the binary (default: strip it)
+#   ARCH          target arch for appimagetool (default: x86_64)
+#   CACHE_DIR     where to cache appimagetool (default: <repo>/packaging/.cache)
+#
+set -euo pipefail
+
+# ----------------------------------------------------------------------------
+# Locate repo root (this script lives in <repo>/packaging/).
+# ----------------------------------------------------------------------------
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+ARCH="${ARCH:-x86_64}"
+export ARCH
+OUTPUT_DIR="${OUTPUT:-${REPO_ROOT}}"
+CACHE_DIR="${CACHE_DIR:-${SCRIPT_DIR}/.cache}"
+STRIP_BINARY="${STRIP:-1}"
+OUTPUT_NAME="Zathura_Debugger-${ARCH}.AppImage"
+
+NO_BUILD=0
+for arg in "$@"; do
+    case "${arg}" in
+        --no-build) NO_BUILD=1 ;;
+        *) echo "Unknown argument: ${arg}" >&2; exit 2 ;;
+    esac
+done
+
+# ----------------------------------------------------------------------------
+# Version.
+# ----------------------------------------------------------------------------
+if [[ -n "${VERSION:-}" ]]; then
+    APP_VERSION="${VERSION}"
+elif [[ -f "${REPO_ROOT}/VERSION" ]]; then
+    APP_VERSION="$(tr -d '[:space:]' < "${REPO_ROOT}/VERSION")"
+else
+    APP_VERSION="0.0.0"
+fi
+echo "==> ZathuraDbg AppImage build (version ${APP_VERSION}, arch ${ARCH})"
+
+# ----------------------------------------------------------------------------
+# 1. Build (unless --no-build).
+# ----------------------------------------------------------------------------
+BUILD_DIR="${REPO_ROOT}/src/build"
+if [[ "${NO_BUILD}" -eq 0 ]]; then
+    echo "==> Configuring and building Zathura (Release)"
+    CMAKE_ARGS=(-S "${REPO_ROOT}/src" -B "${BUILD_DIR}" -G Ninja -DCMAKE_BUILD_TYPE=Release)
+    # Prefer gcc-14/g++-14 when available (matches native CI), but do not hard-fail
+    # if they are absent on a developer machine.
+    if command -v gcc-14 >/dev/null 2>&1 && command -v g++-14 >/dev/null 2>&1; then
+        CMAKE_ARGS+=(-DCMAKE_C_COMPILER=gcc-14 -DCMAKE_CXX_COMPILER=g++-14)
+    fi
+    cmake "${CMAKE_ARGS[@]}"
+    cmake --build "${BUILD_DIR}" -j"$(nproc)"
+else
+    echo "==> --no-build: skipping compilation, packaging existing binary"
+fi
+
+# ----------------------------------------------------------------------------
+# 2. Locate the built binary.
+# ----------------------------------------------------------------------------
+ZATHURA_BIN=""
+for candidate in "${REPO_ROOT}/src/Zathura" "${BUILD_DIR}/Zathura"; do
+    if [[ -x "${candidate}" ]]; then
+        ZATHURA_BIN="${candidate}"
+        break
+    fi
+done
+if [[ -z "${ZATHURA_BIN}" ]]; then
+    echo "ERROR: could not find a built Zathura binary in src/ or src/build/." >&2
+    echo "       Run without --no-build, or place the binary at src/Zathura." >&2
+    exit 1
+fi
+echo "==> Using binary: ${ZATHURA_BIN}"
+
+# ----------------------------------------------------------------------------
+# 3. Assemble AppDir.
+# ----------------------------------------------------------------------------
+APPDIR="${REPO_ROOT}/AppDir"
+echo "==> Assembling AppDir at ${APPDIR}"
+rm -rf "${APPDIR}"
+mkdir -p \
+    "${APPDIR}/usr/bin" \
+    "${APPDIR}/usr/lib" \
+    "${APPDIR}/usr/assets" \
+    "${APPDIR}/usr/vendor" \
+    "${APPDIR}/usr/share/applications" \
+    "${APPDIR}/usr/share/icons/hicolor/256x256/apps"
+
+# 3a. Binary.
+cp -f "${ZATHURA_BIN}" "${APPDIR}/usr/bin/Zathura"
+chmod +x "${APPDIR}/usr/bin/Zathura"
+if [[ "${STRIP_BINARY}" != "0" ]] && command -v strip >/dev/null 2>&1; then
+    echo "==> Stripping binary (set STRIP=0 to keep symbols)"
+    strip --strip-unneeded "${APPDIR}/usr/bin/Zathura" || \
+        echo "    (strip failed, continuing with unstripped binary)"
+fi
+
+# 3b. Bundle shared libraries.
+#
+# Strategy: ship the vendored keystone, plus an allowlist of libs that are not
+# safe to assume on a target system. We deliberately do NOT bundle libc,
+# libstdc++, libgcc_s, libm, libdl, the mesa GL driver (libGL), or core
+# X11/xcb -- those must come from the host. This matches the released image.
+LIB_ALLOWLIST=(
+    libglfw.so.3
+    libGLU.so.1
+    libssl.so.3
+    libcrypto.so.3
+    libXau.so.6
+    libXdmcp.so.6
+    libkeystone.so.0
+    libunicorn.so.2
+)
+
+in_allowlist() {
+    local name="$1"
+    for allowed in "${LIB_ALLOWLIST[@]}"; do
+        [[ "${name}" == "${allowed}" ]] && return 0
+    done
+    return 1
+}
+
+echo "==> Bundling libraries into usr/lib"
+# Vendored keystone (preferred source; always present in-tree).
+shopt -s nullglob
+for ks in "${REPO_ROOT}"/vendor/local/usr/local/lib/libkeystone.so.0*; do
+    cp -Lf "${ks}" "${APPDIR}/usr/lib/libkeystone.so.0"
+    echo "    + libkeystone.so.0 (vendored)"
+done
+shopt -u nullglob
+
+# Everything else, derived from ldd against the real binary.
+if command -v ldd >/dev/null 2>&1; then
+    while read -r name _arrow path _addr; do
+        # ldd lines look like: "libfoo.so.1 => /path/libfoo.so.1 (0x...)"
+        [[ "${name}" == */* ]] && continue          # skip the dynamic loader line
+        [[ -z "${path:-}" || "${path}" == "not" ]] && continue
+        [[ -e "${path}" ]] || continue
+        base="$(basename "${name}")"
+        in_allowlist "${base}" || continue
+        # keystone already handled from the vendored copy.
+        [[ "${base}" == "libkeystone.so.0" && -e "${APPDIR}/usr/lib/libkeystone.so.0" ]] && continue
+        if [[ ! -e "${APPDIR}/usr/lib/${base}" ]]; then
+            cp -Lf "${path}" "${APPDIR}/usr/lib/${base}"
+            echo "    + ${base} (from ${path})"
+        fi
+    done < <(ldd "${APPDIR}/usr/bin/Zathura" 2>/dev/null)
+else
+    echo "    WARNING: ldd not found; only the vendored keystone was bundled." >&2
+fi
+
+# 3c. Assets and ghidra processor specs (loaded relative to the binary).
+echo "==> Copying assets and vendor/ghidra"
+cp -a "${REPO_ROOT}/assets/." "${APPDIR}/usr/assets/"
+cp -a "${REPO_ROOT}/vendor/ghidra/." "${APPDIR}/usr/vendor/ghidra/"
+
+# 3d. AppRun (kept here as a heredoc so the script is self-contained).
+echo "==> Writing AppRun"
+cat > "${APPDIR}/AppRun" <<'APPRUN'
+#!/usr/bin/bash
+APPDIR="$(dirname "$(readlink -f "$0")")"
+export LD_LIBRARY_PATH="$APPDIR/usr/lib:$LD_LIBRARY_PATH"
+export PATH="$APPDIR/usr/bin:$PATH"
+exec "$APPDIR/usr/bin/Zathura" "$@"
+APPRUN
+chmod +x "${APPDIR}/AppRun"
+
+# 3e. Desktop entry (top-level + usr/share/applications).
+echo "==> Writing desktop entry"
+write_desktop() {
+    cat > "$1" <<'DESKTOP'
+[Desktop Entry]
+Type=Application
+Name=Zathura Debugger
+Exec=Zathura
+Icon=ZathuraDbg
+Categories=Development;
+DESKTOP
+}
+write_desktop "${APPDIR}/ZathuraDbg.desktop"
+write_desktop "${APPDIR}/usr/share/applications/ZathuraDbg.desktop"
+
+# 3f. Icon (top-level + hicolor) + .DirIcon symlink.
+echo "==> Placing icon"
+ICON_SRC="${REPO_ROOT}/assets/ZathuraDbg.png"
+if [[ ! -f "${ICON_SRC}" ]]; then
+    echo "ERROR: icon not found at ${ICON_SRC}" >&2
+    exit 1
+fi
+cp -f "${ICON_SRC}" "${APPDIR}/ZathuraDbg.png"
+cp -f "${ICON_SRC}" "${APPDIR}/usr/share/icons/hicolor/256x256/apps/ZathuraDbg.png"
+ln -sf "ZathuraDbg.png" "${APPDIR}/.DirIcon"
+
+# ----------------------------------------------------------------------------
+# 4. Fetch appimagetool (cached) and build the AppImage.
+# ----------------------------------------------------------------------------
+mkdir -p "${CACHE_DIR}"
+APPIMAGETOOL="${CACHE_DIR}/appimagetool-${ARCH}.AppImage"
+if [[ ! -x "${APPIMAGETOOL}" ]]; then
+    echo "==> Downloading appimagetool"
+    URL="https://github.com/AppImage/appimagetool/releases/download/continuous/appimagetool-${ARCH}.AppImage"
+    if command -v curl >/dev/null 2>&1; then
+        curl -fSL "${URL}" -o "${APPIMAGETOOL}"
+    else
+        wget -O "${APPIMAGETOOL}" "${URL}"
+    fi
+    chmod +x "${APPIMAGETOOL}"
+fi
+
+mkdir -p "${OUTPUT_DIR}"
+OUTPUT_PATH="${OUTPUT_DIR}/${OUTPUT_NAME}"
+echo "==> Running appimagetool"
+# --appimage-extract-and-run avoids needing FUSE (important in CI containers).
+# Pass VERSION through so appimagetool can embed it.
+VERSION="${APP_VERSION}" "${APPIMAGETOOL}" --appimage-extract-and-run \
+    "${APPDIR}" "${OUTPUT_PATH}"
+
+# ----------------------------------------------------------------------------
+# 5. Report.
+# ----------------------------------------------------------------------------
+echo ""
+echo "==> Done."
+echo "    Output: ${OUTPUT_PATH}"
+ls -la "${OUTPUT_PATH}"

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -122,8 +122,13 @@ cp -f "${ZATHURA_BIN}" "${APPDIR}/usr/bin/Zathura"
 chmod +x "${APPDIR}/usr/bin/Zathura"
 if [[ "${STRIP_BINARY}" != "0" ]] && command -v strip >/dev/null 2>&1; then
     echo "==> Stripping binary (set STRIP=0 to keep symbols)"
-    strip --strip-unneeded "${APPDIR}/usr/bin/Zathura" || \
-        echo "    (strip failed, continuing with unstripped binary)"
+    # Strip in place, but restore the known-good binary if strip fails partway
+    # so a corrupted executable is never packaged.
+    if ! strip --strip-unneeded "${APPDIR}/usr/bin/Zathura"; then
+        echo "    (strip failed; restoring unstripped binary)"
+        cp -f "${ZATHURA_BIN}" "${APPDIR}/usr/bin/Zathura"
+        chmod +x "${APPDIR}/usr/bin/Zathura"
+    fi
 fi
 
 # 3a-bis. Default sample file. The app opens "test.asm" relative to the

--- a/packaging/build-appimage.sh
+++ b/packaging/build-appimage.sh
@@ -162,33 +162,53 @@ in_allowlist() {
 }
 
 echo "==> Bundling libraries into usr/lib"
-# Vendored keystone (preferred source; always present in-tree).
-shopt -s nullglob
-for ks in "${REPO_ROOT}"/vendor/local/usr/local/lib/libkeystone.so.0*; do
-    cp -Lf "${ks}" "${APPDIR}/usr/lib/libkeystone.so.0"
-    echo "    + libkeystone.so.0 (vendored)"
-done
-shopt -u nullglob
+# Vendored keystone (preferred source; always present in-tree). Resolve exactly
+# one source file deterministically: the unversioned SONAME if it exists,
+# otherwise the highest-sorting versioned match. (A glob loop that copies every
+# match onto the same destination name would be order-dependent.)
+keystone_src="${REPO_ROOT}/vendor/local/usr/local/lib/libkeystone.so.0"
+if [[ ! -e "${keystone_src}" ]]; then
+    shopt -s nullglob
+    keystone_matches=("${REPO_ROOT}"/vendor/local/usr/local/lib/libkeystone.so.0*)
+    shopt -u nullglob
+    (( ${#keystone_matches[@]} )) && keystone_src="${keystone_matches[-1]}"
+fi
+if [[ -e "${keystone_src}" ]]; then
+    cp -Lf "${keystone_src}" "${APPDIR}/usr/lib/libkeystone.so.0"
+    echo "    + libkeystone.so.0 (vendored, from ${keystone_src})"
+else
+    echo "ERROR: vendored libkeystone.so.0 not found under vendor/local." >&2
+    exit 1
+fi
 
 # Everything else, derived from ldd against the real binary.
-if command -v ldd >/dev/null 2>&1; then
-    while read -r name _arrow path _addr; do
-        # ldd lines look like: "libfoo.so.1 => /path/libfoo.so.1 (0x...)"
-        [[ "${name}" == */* ]] && continue          # skip the dynamic loader line
-        [[ -z "${path:-}" || "${path}" == "not" ]] && continue
-        [[ -e "${path}" ]] || continue
-        base="$(basename "${name}")"
-        in_allowlist "${base}" || continue
-        # keystone already handled from the vendored copy.
-        [[ "${base}" == "libkeystone.so.0" && -e "${APPDIR}/usr/lib/libkeystone.so.0" ]] && continue
-        if [[ ! -e "${APPDIR}/usr/lib/${base}" ]]; then
-            cp -Lf "${path}" "${APPDIR}/usr/lib/${base}"
-            echo "    + ${base} (from ${path})"
-        fi
-    done < <(ldd "${APPDIR}/usr/bin/Zathura" 2>/dev/null)
-else
-    echo "    WARNING: ldd not found; only the vendored keystone was bundled." >&2
+command -v ldd >/dev/null 2>&1 || { echo "ERROR: ldd not found; cannot resolve runtime libraries." >&2; exit 1; }
+
+# Capture ldd output once and sanity-check it: an empty result, or one without
+# any "=>" resolution lines, means the binary is static or ldd failed -- in
+# which case bundling only keystone would silently ship a broken AppImage.
+ldd_output="$(ldd "${APPDIR}/usr/bin/Zathura" 2>/dev/null || true)"
+if ! grep -q '=>' <<<"${ldd_output}"; then
+    echo "ERROR: ldd reported no shared-library dependencies for the binary." >&2
+    echo "       It may be statically linked or ldd failed; refusing to ship a" >&2
+    echo "       half-bundled AppImage." >&2
+    exit 1
 fi
+
+while read -r name _arrow path _addr; do
+    # ldd lines look like: "libfoo.so.1 => /path/libfoo.so.1 (0x...)"
+    [[ "${name}" == */* ]] && continue              # skip the dynamic loader line
+    [[ -z "${path:-}" || "${path}" == "not" ]] && continue
+    [[ -e "${path}" ]] || continue
+    base="$(basename "${name}")"
+    in_allowlist "${base}" || continue
+    # keystone already handled from the vendored copy.
+    [[ "${base}" == "libkeystone.so.0" ]] && continue
+    if [[ ! -e "${APPDIR}/usr/lib/${base}" ]]; then
+        cp -Lf "${path}" "${APPDIR}/usr/lib/${base}"
+        echo "    + ${base} (from ${path})"
+    fi
+done <<<"${ldd_output}"
 
 # 3c. Assets and ghidra processor specs (loaded relative to the binary).
 echo "==> Copying assets and vendor/ghidra"


### PR DESCRIPTION
## Summary

Adds a repeatable AppImage build + publishing pipeline that reproduces the project's current released AppImage layout (`Zathura_Debugger-x86_64.AppImage`).

- **`packaging/build-appimage.sh`** — self-contained script (`set -euo pipefail`) that:
  - reads `VERSION` (overridable via `$VERSION`), builds a Release `Zathura` with cmake/ninja (gcc-14/g++-14 when available, matching native CI), or skips building with `--no-build` to repackage a prebuilt binary;
  - assembles `AppDir/` matching the released layout — top-level `AppRun`, `ZathuraDbg.desktop`, `ZathuraDbg.png`, `.DirIcon`; binary at `usr/bin/Zathura`; libs in `usr/lib/`; `assets/`→`usr/assets/` and `vendor/ghidra/`→`usr/vendor/ghidra/` so the binary's relative `../assets` / `../vendor/ghidra` lookups resolve; `usr/share/applications` + `usr/share/icons/hicolor/256x256/apps`;
  - bundles the vendored keystone plus an `ldd`-derived allowlist (`libglfw`, `libGLU`, `libssl`, `libcrypto`, `libXau`, `libXdmcp`, `libkeystone`, `libunicorn` if linked); leaves libc/libstdc++/libgcc_s/libm/libGL/X11-core to the host;
  - downloads + caches `appimagetool`, runs it with `--appimage-extract-and-run` (no FUSE), emits the `.AppImage` in the repo root (or `$OUTPUT`);
  - supports `STRIP`/`VERSION`/`OUTPUT`/`ARCH`/`CACHE_DIR` overrides.
- **`.github/workflows/appimage.yml`** — triggers only on tag pushes, runs on `ubuntu-latest`, installs the apt build deps, runs the script, and publishes the AppImage to that tag's GitHub Release via `softprops/action-gh-release@v2` (`permissions: contents: write`, `fail_on_unmatched_files: true`).
- **`packaging/README.md`** — local build, tag-triggered publishing, AppDir layout, lib-bundling/glibc notes.
- `.gitignore` entries for `AppDir/`, the output AppImage, and `packaging/.cache/`.

## How to use

- Local: `bash packaging/build-appimage.sh`
- Publish: `git tag v1.0 && git push origin v1.0`

## Verification

Verified by running the script in `--no-build` mode against the released prebuilt binary, then extracting the resulting AppImage and diffing its structure against the current released image:

- Directory tree and `usr/lib` set match the released image exactly, except the two intentional deviations below.
- `AppRun`, `.desktop`, icon, `.DirIcon`, `usr/assets` (8 fonts + icon), and `usr/vendor/ghidra` (608 files) all present and correct.
- Resulting AppImage size: **~15.4 MB** (stripped) vs the released ~150 MB unstripped.

## Intentional deviations from the current AppImage

- **`libicicle.a` excluded** — a static archive is linked at build time and never loaded at runtime; bundling it was ~45 MB of dead weight. Functionally identical.
- **Binary stripped by default** (skippable via `STRIP=0`) — the released binary was unstripped.

(The released image also contained empty placeholder icon-size dirs under `usr/share/icons/hicolor/`; those held no files and are inconsequential.)