### PR TITLE
Fix dialog error messages hidden by tinyfd quote rejection

### DIFF
--- a/src/app/actions/actions.cpp
+++ b/src/app/actions/actions.cpp
@@ -1,4 +1,5 @@
 #include <thread>
+#include "../dialogs/safeDialogs.hpp"
 #include <condition_variable>
 #include <functional>
 #ifdef _WIN32
@@ -130,7 +131,7 @@ void updateWindow()
         currentVersion = getLatestVersion();
         if (currentVersion.empty())
         {
-            if (tinyfd_messageBox("Error", "Failed to check for updates! Your internet may not be working", "ok", "error", 0))
+            if (Zathura::safeMessageBox("Error", "Failed to check for updates! Your internet may not be working", "ok", "error", 0))
             {
                 return;
             }

--- a/src/app/dialogs/safeDialogs.hpp
+++ b/src/app/dialogs/safeDialogs.hpp
@@ -52,9 +52,12 @@ inline std::string sanitizeForTinyfd(const char* text) {
 inline int safeMessageBox(const char* title, const char* message,
                           const char* dialogType, const char* iconType,
                           const int defaultButton) {
+    // Pass NULL through unchanged rather than normalizing it to "": tinyfd
+    // accepts a NULL title/message and we must not silently alter that contract.
     const std::string safeTitle = sanitizeForTinyfd(title);
     const std::string safeMessage = sanitizeForTinyfd(message);
-    return tinyfd_messageBox(safeTitle.c_str(), safeMessage.c_str(),
+    return tinyfd_messageBox(title != nullptr ? safeTitle.c_str() : nullptr,
+                             message != nullptr ? safeMessage.c_str() : nullptr,
                              dialogType, iconType, defaultButton);
 }
 

--- a/src/app/dialogs/safeDialogs.hpp
+++ b/src/app/dialogs/safeDialogs.hpp
@@ -1,6 +1,7 @@
 #ifndef ZATHURA_UI_SAFEDIALOGS_HPP
 #define ZATHURA_UI_SAFEDIALOGS_HPP
 
+#include <cctype>
 #include <string>
 #include <tinyfiledialogs.h>
 
@@ -28,7 +29,20 @@ inline std::string sanitizeForTinyfd(const char* text) {
             case '\'': out += "\xE2\x80\x99"; break; // U+2019 right single quote
             case '"':  out += "\xE2\x80\x9D"; break; // U+201D right double quote
             case '`':  out += "\xE2\x80\x98"; break; // U+2018 left single quote
-            case '$':  out += "\xEF\xBC\x84"; break; // U+FF04 fullwidth dollar
+            case '$': {
+                // tinyfiledialogs only rejects '$' when it begins a shell
+                // expansion ('$(' , '$_' or '$<letter>'); see tfd_quoteDetected.
+                // Leave any other '$' (e.g. "$5", a trailing "$") untouched so
+                // legitimate text -- common in a debugger UI -- is preserved.
+                const char next = *(p + 1); // safe: reads the NUL at most
+                if (next == '(' || next == '_' ||
+                    std::isalpha(static_cast<unsigned char>(next))) {
+                    out += "\xEF\xBC\x84"; // U+FF04 fullwidth dollar
+                } else {
+                    out += '$';
+                }
+                break;
+            }
             default:   out += *p;             break;
         }
     }
@@ -44,25 +58,9 @@ inline int safeMessageBox(const char* title, const char* message,
                              dialogType, iconType, defaultButton);
 }
 
-inline int safeNotifyPopup(const char* title, const char* message,
-                           const char* iconType) {
-    const std::string safeTitle = sanitizeForTinyfd(title);
-    const std::string safeMessage = sanitizeForTinyfd(message);
-    return tinyfd_notifyPopup(safeTitle.c_str(), safeMessage.c_str(), iconType);
-}
-
-inline const char* safeInputBox(const char* title, const char* message,
-                                const char* defaultInput) {
-    const std::string safeTitle = sanitizeForTinyfd(title);
-    const std::string safeMessage = sanitizeForTinyfd(message);
-    // A NULL defaultInput requests a hidden password field; preserve that.
-    if (defaultInput == nullptr) {
-        return tinyfd_inputBox(safeTitle.c_str(), safeMessage.c_str(), nullptr);
-    }
-    const std::string safeDefault = sanitizeForTinyfd(defaultInput);
-    return tinyfd_inputBox(safeTitle.c_str(), safeMessage.c_str(),
-                           safeDefault.c_str());
-}
+// Note: only the messageBox wrapper exists because that is the only tinyfd
+// dialog the app currently raises. Add safeNotifyPopup / safeInputBox the same
+// way (sanitize each user-facing argument) when a caller actually needs them.
 
 } // namespace Zathura
 

--- a/src/app/dialogs/safeDialogs.hpp
+++ b/src/app/dialogs/safeDialogs.hpp
@@ -1,0 +1,69 @@
+#ifndef ZATHURA_UI_SAFEDIALOGS_HPP
+#define ZATHURA_UI_SAFEDIALOGS_HPP
+
+#include <string>
+#include <tinyfiledialogs.h>
+
+// tinyfiledialogs refuses to display any title/message containing characters it
+// treats as shell-dangerous (see tfd_quoteDetected in tinyfiledialogs.c): a
+// single quote ('), double quote ("), backtick (`), or a '$' that begins a
+// shell expansion. When one is present it silently substitutes the literal text
+// "INVALID MESSAGE WITH QUOTES", hiding the real message from the user.
+//
+// These wrappers sanitize user-facing strings by swapping those ASCII
+// characters for visually-equivalent Unicode glyphs that tinyfiledialogs
+// accepts, so the intended text is always shown -- including dynamic content
+// such as file names that may legitimately contain quotes. Encoded as explicit
+// UTF-8 bytes to stay independent of the compiler's execution charset.
+
+namespace Zathura {
+
+inline std::string sanitizeForTinyfd(const char* text) {
+    std::string out;
+    if (text == nullptr) {
+        return out;
+    }
+    for (const char* p = text; *p != '\0'; ++p) {
+        switch (*p) {
+            case '\'': out += "\xE2\x80\x99"; break; // U+2019 right single quote
+            case '"':  out += "\xE2\x80\x9D"; break; // U+201D right double quote
+            case '`':  out += "\xE2\x80\x98"; break; // U+2018 left single quote
+            case '$':  out += "\xEF\xBC\x84"; break; // U+FF04 fullwidth dollar
+            default:   out += *p;             break;
+        }
+    }
+    return out;
+}
+
+inline int safeMessageBox(const char* title, const char* message,
+                          const char* dialogType, const char* iconType,
+                          const int defaultButton) {
+    const std::string safeTitle = sanitizeForTinyfd(title);
+    const std::string safeMessage = sanitizeForTinyfd(message);
+    return tinyfd_messageBox(safeTitle.c_str(), safeMessage.c_str(),
+                             dialogType, iconType, defaultButton);
+}
+
+inline int safeNotifyPopup(const char* title, const char* message,
+                           const char* iconType) {
+    const std::string safeTitle = sanitizeForTinyfd(title);
+    const std::string safeMessage = sanitizeForTinyfd(message);
+    return tinyfd_notifyPopup(safeTitle.c_str(), safeMessage.c_str(), iconType);
+}
+
+inline const char* safeInputBox(const char* title, const char* message,
+                                const char* defaultInput) {
+    const std::string safeTitle = sanitizeForTinyfd(title);
+    const std::string safeMessage = sanitizeForTinyfd(message);
+    // A NULL defaultInput requests a hidden password field; preserve that.
+    if (defaultInput == nullptr) {
+        return tinyfd_inputBox(safeTitle.c_str(), safeMessage.c_str(), nullptr);
+    }
+    const std::string safeDefault = sanitizeForTinyfd(defaultInput);
+    return tinyfd_inputBox(safeTitle.c_str(), safeMessage.c_str(),
+                           safeDefault.c_str());
+}
+
+} // namespace Zathura
+
+#endif // ZATHURA_UI_SAFEDIALOGS_HPP

--- a/src/app/integration/keystone/assembler.cpp
+++ b/src/app/integration/keystone/assembler.cpp
@@ -1,4 +1,5 @@
 #include "assembler.hpp"
+#include "../../dialogs/safeDialogs.hpp"
 #include "../interpreter/interpreter.hpp"
 #include <capstone/capstone.h>
 #include <algorithm>
@@ -28,7 +29,7 @@ std::pair<std::string, std::size_t> assemble(const std::string& assemblyString, 
         err = ks_open(ksSettings.arch, ksSettings.mode, &ks);
 
         if (err != KS_ERR_OK) {
-            tinyfd_messageBox("ERROR!","Failed to initialize Keystone engine!", "ok", "error", 0);
+            Zathura::safeMessageBox("ERROR!","Failed to initialize Keystone engine!", "ok", "error", 0);
             return {"", 0};
         }
 
@@ -47,12 +48,12 @@ std::pair<std::string, std::size_t> assemble(const std::string& assemblyString, 
         const std::string error(ks_strerror(err));
         if (err == KS_ERR_ASM_INVALIDOPERAND){
             LOG_ERROR("Wrong architecture error!: " << error);
-            tinyfd_messageBox("Assembly syntax error!", "The code does not belong to the currently selected architecture!"
+            Zathura::safeMessageBox("Assembly syntax error!", "The code does not belong to the currently selected architecture!"
                                     "\nPlease change the architecture in the settings.", "ok", "error", 0);
         }
         else if (err >= KS_ERR_ASM){
             LOG_ERROR("Assembly syntax error: " << error);
-            tinyfd_messageBox("Assembly syntax error!", error.c_str(), "ok", "error", 0);
+            Zathura::safeMessageBox("Assembly syntax error!", error.c_str(), "ok", "error", 0);
         }
 
         LOG_ERROR(error);
@@ -306,7 +307,7 @@ bool updateInstructionSizes(const std::string& compiledAsm){
         LOG_ERROR("  - Mode: " << codeInformation.modeCS);
         LOG_ERROR("  - Entry point: 0x" << std::hex << ENTRY_POINT_ADDRESS);
         LOG_ERROR("  - Data size: " << std::dec << compiledAsm.length());
-        tinyfd_messageBox("Unable to run the given code!\n",  "Please check the logs and create an issue on GitHub if the issue persists", "ok", "error", 0);
+        Zathura::safeMessageBox("Unable to run the given code!\n",  "Please check the logs and create an issue on GitHub if the issue persists", "ok", "error", 0);
         cs_close(&handle);
         return false;
     }
@@ -319,7 +320,7 @@ std::string getBytes(const std::string& fileName){
 
     if (!asmFile.is_open()){
         LOG_ERROR("File can not be read: getBytes(" << fileName << ")");
-        tinyfd_messageBox("File read error!", "Asm file cannot be read!", "ok", "error", 0);
+        Zathura::safeMessageBox("File read error!", "Asm file cannot be read!", "ok", "error", 0);
         return "";
     }
     assembly.clear();

--- a/src/app/integration/keystone/assembler.cpp
+++ b/src/app/integration/keystone/assembler.cpp
@@ -319,7 +319,7 @@ std::string getBytes(const std::string& fileName){
 
     if (!asmFile.is_open()){
         LOG_ERROR("File can not be read: getBytes(" << fileName << ")");
-        tinyfd_messageBox("File read error!", "Asm file can't be read!", "ok", "error", 0);
+        tinyfd_messageBox("File read error!", "Asm file cannot be read!", "ok", "error", 0);
         return "";
     }
     assembly.clear();

--- a/src/app/integration/keystone/assembler.cpp
+++ b/src/app/integration/keystone/assembler.cpp
@@ -320,7 +320,7 @@ std::string getBytes(const std::string& fileName){
 
     if (!asmFile.is_open()){
         LOG_ERROR("File can not be read: getBytes(" << fileName << ")");
-        Zathura::safeMessageBox("File read error!", "Asm file cannot be read!", "ok", "error", 0);
+        Zathura::safeMessageBox("File read error!", "Asm file can't be read!", "ok", "error", 0);
         return "";
     }
     assembly.clear();

--- a/src/app/menuBar.cpp
+++ b/src/app/menuBar.cpp
@@ -1,4 +1,5 @@
 #include "app.hpp"
+#include "dialogs/safeDialogs.hpp"
 bool firstTime = true;
 const char* architectureStrings[] = {"Intel x86_64", "AArch32", "AArch64", "RISC-V", "PowerPC"};
 const char* ksSyntaxOptStr[] = {"Intel", "AT&T", "NASM", "GAS"};
@@ -220,7 +221,7 @@ void changeEmulationSettings(){
             currentDefinitionId = TextEditor::LanguageDefinitionId::AsmArm;
         }
         else {
-            tinyfd_messageBox("Unsupported Architecture!", "Only x86 and ARM Architectures are supported with ZathuraDbg at this point."
+            Zathura::safeMessageBox("Unsupported Architecture!", "Only x86 and ARM Architectures are supported with ZathuraDbg at this point."
                                                            "\nOthers will be coming sooner.", "ok", "info", 0);
             selectedArch = arch::x86;
             ucMode = UC_MODE_64;

--- a/src/app/tasks/editorTasks.cpp
+++ b/src/app/tasks/editorTasks.cpp
@@ -43,7 +43,7 @@ bool readFileIntoEditor(const std::string &filePath) {
         return true;
     }
 
-    Zathura::safeMessageBox("File read error!", "Unable to read the file you are trying to open. Please check if the "
+    Zathura::safeMessageBox("File read error!", "Unable to read the file you're trying to open. Please check if the "
                        "file is not open in another program and/or you have the permissions to read it.",
                       "ok", "error", 0);
 

--- a/src/app/tasks/editorTasks.cpp
+++ b/src/app/tasks/editorTasks.cpp
@@ -42,7 +42,7 @@ bool readFileIntoEditor(const std::string &filePath) {
         return true;
     }
 
-    tinyfd_messageBox("File read error!", "Unable to read the file you're trying to open. Please check if the "
+    tinyfd_messageBox("File read error!", "Unable to read the file you are trying to open. Please check if the "
                        "file is not open in another program and/or you have the permissions to read it.",
                       "ok", "error", 0);
 

--- a/src/app/tasks/editorTasks.cpp
+++ b/src/app/tasks/editorTasks.cpp
@@ -1,4 +1,5 @@
 #include "editorTasks.hpp"
+#include "../dialogs/safeDialogs.hpp"
 #include "../integration/keystone/assembler.hpp"
 #include "../app.hpp"
 #include <cctype>
@@ -9,7 +10,7 @@ bool writeEditorToFile(const std::string &filePath) {
     LOG_DEBUG("Writing to file " << filePath);
 
     if (editorShowingRemoteDisassembly()) {
-        tinyfd_messageBox("Remote View Active",
+        Zathura::safeMessageBox("Remote View Active",
                           "The main editor is currently showing remote target disassembly.\nStop the remote session before saving local files.",
                           "ok", "warning", 0);
         return false;
@@ -24,7 +25,7 @@ bool writeEditorToFile(const std::string &filePath) {
         return true;
     }
 
-    tinyfd_messageBox("File write error!", ("Unable to write to the file " + filePath + "!\nPlease check if the "
+    Zathura::safeMessageBox("File write error!", ("Unable to write to the file " + filePath + "!\nPlease check if the "
                       "file is not open in another program and/or you have the permissions to read it.").c_str(),
                       "ok", "error", 0);
     return false;
@@ -42,7 +43,7 @@ bool readFileIntoEditor(const std::string &filePath) {
         return true;
     }
 
-    tinyfd_messageBox("File read error!", "Unable to read the file you are trying to open. Please check if the "
+    Zathura::safeMessageBox("File read error!", "Unable to read the file you are trying to open. Please check if the "
                        "file is not open in another program and/or you have the permissions to read it.",
                       "ok", "error", 0);
 
@@ -237,7 +238,7 @@ void pasteCallback(const std::string clipboardText) {
             return;
         }
 
-        const int res = tinyfd_messageBox("Valid shellcode found!",
+        const int res = Zathura::safeMessageBox("Valid shellcode found!",
             "It looks like you are trying to paste shellcode.\n"
             "Do you want ZathuraDbg to automatically disassemble this shellcode?",
             "yesno", "question", 0);

--- a/src/app/tasks/fileTasks.cpp
+++ b/src/app/tasks/fileTasks.cpp
@@ -1,4 +1,5 @@
 #include "fileTasks.hpp"
+#include "../dialogs/safeDialogs.hpp"
 #include <mutex>
 #include "../app.hpp"
 #include "../integration/elfLoader.hpp"
@@ -89,7 +90,7 @@ bool fileRunTask(const bool& execCode){
             }
         }
         else{
-            tinyfd_messageBox("Stack creation failed!", "The app was unable to create the stack to run the code.\nPlease try restarting it or report this issue on github!",
+            Zathura::safeMessageBox("Stack creation failed!", "The app was unable to create the stack to run the code.\nPlease try restarting it or report this issue on github!",
                 "ok", "error", 0);
 
             LOG_ERROR("Unable to create stack!, quitting!");
@@ -98,7 +99,7 @@ bool fileRunTask(const bool& execCode){
     }
     else{
         LOG_ERROR("No file selected to run!");
-        tinyfd_messageBox("No file selected!", "Please open a file to run the code!", "ok", "error", 0);
+        Zathura::safeMessageBox("No file selected!", "Please open a file to run the code!", "ok", "error", 0);
         return false;
     }
 

--- a/src/app/windows/hexEditorWindow.cpp
+++ b/src/app/windows/hexEditorWindow.cpp
@@ -1,4 +1,5 @@
 #include "windows.hpp"
+#include "../dialogs/safeDialogs.hpp"
 #include "../app.hpp"
 #include "../integration/debugState.hpp"
 
@@ -25,7 +26,7 @@ void hexWriteFunc(ImU8* data, const size_t off, const ImU8 d){
         const auto hex = static_cast<char *>(malloc(24));
         sprintf(static_cast<char *>(hex), "Data change: %x", d);
         LOG_ERROR(hex);
-        tinyfd_messageBox("ERROR!", "Failed to write to the memory address!!", "ok", "error", 0);
+        Zathura::safeMessageBox("ERROR!", "Failed to write to the memory address!!", "ok", "error", 0);
         free(hex);
     }
 }

--- a/src/app/windows/memoryMapView.cpp
+++ b/src/app/windows/memoryMapView.cpp
@@ -1,4 +1,5 @@
 #include "windows.hpp"
+#include "../dialogs/safeDialogs.hpp"
 
 bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAddr, uint64_t newEndAddr,
                         const uint64_t oldSize, const MemoryProtection perms)
@@ -25,7 +26,7 @@ bool expandMemoryRegion(Icicle* ic, const uint64_t startAddr, uint64_t oldEndAdd
     if (((newSize % 4096) != 0))
     {
         LOG_ALERT("The new size requested for the memory region is not a multiple of 4096, rounding up...");
-        tinyfd_messageBox(
+        Zathura::safeMessageBox(
             "Warning",
             "The new end address provided by you is not a multiple of the page size. The number will be rounded up to a multiple of 4KB.",
             "ok", "warning", 1);
@@ -320,7 +321,7 @@ void memoryMapWindow()
                 ImGui::Checkbox("###Check4_", &mapped);
                 if (ImGui::IsItemHovered() && ImGui::IsMouseReleased(0))
                 {
-                    bool unmap = tinyfd_messageBox("Confirmation required!", "Are you sure you want to unmap it?", "okcancel", "error", 0);
+                    bool unmap = Zathura::safeMessageBox("Confirmation required!", "Are you sure you want to unmap it?", "okcancel", "error", 0);
 
                     if (unmap)
                     {

--- a/src/app/windows/stackWindow.cpp
+++ b/src/app/windows/stackWindow.cpp
@@ -1,4 +1,5 @@
 #include "windows.hpp"
+#include "../dialogs/safeDialogs.hpp"
 #include "../integration/debugState.hpp"
 
 #include <algorithm>
@@ -75,7 +76,7 @@ void stackWriteFunc(ImU8* data, const size_t offset, const ImU8 delta) {
 
     if (!writeOk) {
         LOG_ERROR("Failed to write to memory. Address: 0x" << std::hex << address);
-        tinyfd_messageBox("ERROR!", "Failed to write to the memory address!!", "ok", "error", 0);
+        Zathura::safeMessageBox("ERROR!", "Failed to write to the memory address!!", "ok", "error", 0);
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,5 +1,6 @@
 #define IMGUI_DEFINE_MATH_OPERATORS
 #include "../vendor/imgui/imgui_internal.h"
+#include "app/dialogs/safeDialogs.hpp"
 #include "../vendor/imgui/imgui.h"
 #include "../vendor/imgui/backends/imgui_impl_glfw.h"
 #include "../vendor/imgui/backends/imgui_impl_opengl3.h"
@@ -64,7 +65,7 @@ void reportStartupWarning(const std::string &message) {
     }
 
     std::cerr << message << '\n';
-    tinyfd_messageBox("ZathuraDbg startup warning", message.c_str(), "ok", "warning", 0);
+    Zathura::safeMessageBox("ZathuraDbg startup warning", message.c_str(), "ok", "warning", 0);
 }
 
 }
@@ -239,7 +240,7 @@ int main(int argc, const char** argv)
             char* path = nullptr;
             path = static_cast<char *>(malloc(length + 1));
             if (path == nullptr) {
-                tinyfd_messageBox("Whereami error!", "Failed to get executable path!", "ok", "error", 0);
+                Zathura::safeMessageBox("Whereami error!", "Failed to get executable path!", "ok", "error", 0);
                 return 1;
             }
             wai_getExecutablePath(path, length, &dirnameLength);
@@ -375,7 +376,7 @@ int main(int argc, const char** argv)
     glfwShowWindow(window);
 
     if (!getenv("GHIDRA_SRC")) {
-        tinyfd_messageBox("Environment variable missing!", "The environment variable GHIDRA_SRC is missing. The emulator can\'t run without this.", "ok", "warning", 0);
+        Zathura::safeMessageBox("Environment variable missing!", "The environment variable GHIDRA_SRC is missing. The emulator can\'t run without this.", "ok", "warning", 0);
     }
 
 #ifdef __EMSCRIPTEN__


### PR DESCRIPTION
## Summary
tinyfiledialogs refuses to display any title/message containing characters its `tfd_quoteDetected()` treats as shell-dangerous — a single quote (`'`), double quote (`"`), backtick (`` ` ``), or a `$` beginning a shell expansion — silently substituting the literal placeholder **"INVALID MESSAGE WITH QUOTES"**. This surfaced on first launch (when the default `test.asm` was missing, the read-error dialog showed only the placeholder).

## Fix
Route every dialog through a sanitizing wrapper so the real message is always shown, including dynamic content such as file names.

- **`src/app/dialogs/safeDialogs.hpp`** — header-only `Zathura::safeMessageBox` + `sanitizeForTinyfd`. Swaps the rejected characters for visually-equivalent Unicode glyphs (`'`→`’`, `"`→`”`, `` ` ``→`‘`). For `$` it mirrors tinyfd's actual rule, only substituting when a shell expansion follows (`$(`, `$_`, `$`+letter) and leaving a bare `$` intact. `NULL` title/message is passed through unchanged.
- Routed all `tinyfd_messageBox` call sites across 9 files through the wrapper.

## Notes
- The wrapper is the single source of truth for quote-safety, so contributors no longer need to hand-avoid apostrophes in dialog strings.
- Only `safeMessageBox` exists (the only dialog type the app raises); the header documents how to add notify/input wrappers when a caller needs them.